### PR TITLE
Application/ascii art stickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,40 @@ Payload length -- 4 bytes gives up to 4GB
 ```bash
 gcc test.c directory_manager.c -ansi -pedantic && ./a.out
 ```
+
+## Features
+
+### Stickers
+ASCII-art stickers can be sent using the command `/sticker`. Sticker operations are as follows:
+<ul>
+    <li>Create</li>
+    <li>Send</li>
+    <li>List</li>
+    <li>Preview</li>
+</ul>
+Stickers previously created are saved and can be retrieved after by logging back in as the user that created them.
+
+#### Feature: Create
+Creates a sticker with the specified name.
+```
+/sticker create <sticker_name>
+```
+This command opens up an editor where user can edit the sticker. Press the `ESC` key to close the editor and save the sticker.
+
+#### Feature: Send
+Sends the sticker to the other users in the chat.
+```
+/sticker send <sticker_name>
+```
+
+#### Feature: List
+Lists all stickers created by the current user.
+```
+/sticker list
+```
+
+#### Feature: Preview
+Previews a particular sticker in user's own terminal without sending it to other users in chat.
+```
+/sticker preview <sticker_name>
+```

--- a/commands_registry.c
+++ b/commands_registry.c
@@ -2,6 +2,7 @@
 #include "base_commands.h"
 /* Add #include directives for any other required headers */
 #include "meow_commands.h"
+#include "sticker_commands.h"
 
 void init_commands(void)
 {
@@ -9,4 +10,5 @@ void init_commands(void)
 
     /* Append any additional command initializations here */
     meow_commands_init();
+    sticker_commands_init();
 }

--- a/commands_registry.h
+++ b/commands_registry.h
@@ -9,6 +9,7 @@ typedef enum
     LMP_NICK = 0x02,
     LMP_ACK = 0x03,
     LMP_MEOW = 0x10,
+    LMP_STICKERS = 0x11,
     LMP_ERROR = 0xFF,
     LMP_UID = 0x04
 } LMPCode;

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -193,7 +193,9 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
             printf("Sticker not found!\n");
         } else {
             printf("%s\n", sticker);
-            lmp_send(ctx->sock, code, sticker, (uint32_t)strlen(sticker));
+            if (lmp_send(ctx->sock, code, sticker, (uint32_t)strlen(sticker)) < 0)
+                return COMMAND_ERROR;
+            lmp_history_append(ctx, ctx->my_nick, sticker);
         }
     } else if (strcmp(command, "list") == 0) {
         printf("Stickers saved:\n");
@@ -219,6 +221,7 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
 /* Called when a LMP_MYCOMMAND packet is received */
 static CommandResult sticker_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx) {
     printf("[%s]: Sent a sticker\n%s\n", ctx->peer_nick, buf);
+    lmp_history_append(ctx, ctx->peer_nick, buf);
     return COMMAND_SUCCESS;
 }
 

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -159,6 +159,7 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
     char *sticker;
     char *name;
     int i;
+    char sticker_newline[MAX_STICKER_LEN] = "\n";
 
     if (history_loaded == 0) {
         load_stickers();
@@ -195,7 +196,9 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
             printf("%s\n", sticker);
             if (lmp_send(ctx->sock, code, sticker, (uint32_t)strlen(sticker)) < 0)
                 return COMMAND_ERROR;
-            lmp_history_append(ctx, ctx->my_nick, sticker);
+
+            strcat(sticker_newline, sticker);
+            lmp_history_append(ctx, ctx->my_nick, sticker_newline);
         }
     } else if (strcmp(command, "list") == 0) {
         printf("Stickers saved:\n");
@@ -220,8 +223,11 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
 
 /* Called when a LMP_MYCOMMAND packet is received */
 static CommandResult sticker_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx) {
+    char buf_newline[MAX_STICKER_LEN] = "Sent a sticker\n";
+
     printf("[%s]: Sent a sticker\n%s\n", ctx->peer_nick, buf);
-    lmp_history_append(ctx, ctx->peer_nick, buf);
+    strcat(buf_newline, buf);
+    lmp_history_append(ctx, ctx->peer_nick, buf_newline);
     return COMMAND_SUCCESS;
 }
 

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -3,10 +3,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
 
 #define MAX_NAME_LEN 32
 #define MAX_STICKERS 64
 #define MAX_STICKER_LEN 2048
+#define ESCAPE 27
 
 typedef struct
 {
@@ -16,11 +19,83 @@ typedef struct
 
 static StickerEntry sticker_array[MAX_STICKERS];
 static size_t sticker_count = 0;
+static struct termios orig_termios;
+
+static void raw_mode_enable(void) {
+    struct termios raw;
+    tcgetattr(STDIN_FILENO, &orig_termios);
+    raw = orig_termios;
+    raw.c_lflag &= ~(ECHO | ICANON);  /* disable echo and line buffering */
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+}
+
+static void raw_mode_disable(void) {
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &orig_termios);
+}
+
+char *read_multiline_overlay(void) {
+    size_t buf_size = 1024;
+    size_t total_len = 0;
+    char *buffer = malloc(buf_size);
+    int c;
+    char *new_buf;
+
+    if (!buffer) return NULL;
+    buffer[0] = '\0';
+
+    raw_mode_enable();
+
+    /* Save cursor position and screen, then clear */
+    printf("\033[?47h");    /* save screen */
+    printf("\033[2J");      /* clear screen */
+    printf("\033[H");       /* cursor to top-left */
+    printf("Enter message (ESC to finish):\n\n");
+    fflush(stdout);
+
+    while ((c = getchar()) != ESCAPE) {
+        if (c == EOF) break;
+
+        /* Handle backspace */
+        if (c == 127 || c == '\b') {
+            if (total_len > 0) {
+                total_len--;
+                buffer[total_len] = '\0';
+                printf("\b \b");
+                fflush(stdout);
+            }
+            continue;
+        }
+
+        /* Grow buffer if needed */
+        if (total_len + 2 > buf_size) {
+            buf_size *= 2;
+            new_buf = realloc(buffer, buf_size);
+            if (!new_buf) { free(buffer); raw_mode_disable(); return NULL; }
+            buffer = new_buf;
+        }
+
+        buffer[total_len++] = (char)c;
+        buffer[total_len] = '\0';
+        putchar(c);
+        fflush(stdout);
+    }
+
+    /* Restore screen */
+    printf("\033[?47l");    /* restore screen */
+    fflush(stdout);
+
+    raw_mode_disable();
+    return buffer;  /* caller must free() */
+}
+
 
 void create_sticker(char *name) {
-    strcpy(sticker_array[sticker_count].sticker, "----------\n---test---\n---aaaa----\n----------");
+    char *user_sticker;
+    user_sticker = read_multiline_overlay();
+    strcpy(sticker_array[sticker_count].sticker, user_sticker);
     strcpy(sticker_array[sticker_count].name, name);
     sticker_count++;
+    printf("Sticker %s created!\n", name);
 }
 
 char *get_sticker(char *name) {
@@ -80,7 +155,7 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
 
 /* Called when a LMP_MYCOMMAND packet is received */
 static CommandResult sticker_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx) {
-    printf("[%s]: \n%s\n", ctx->peer_nick, buf);
+    printf("[%s]: Sent a sticker\n%s\n", ctx->peer_nick, buf);
     return COMMAND_SUCCESS;
 }
 

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -51,7 +51,7 @@ char *read_multiline_overlay(void) {
     printf("\033[?47h");    /* save screen */
     printf("\033[2J");      /* clear screen */
     printf("\033[H");       /* cursor to top-left */
-    printf("Enter message (ESC to finish):\n\n");
+    printf("Enter Sticker (ESC to finish):\n\n");
     fflush(stdout);
 
     while ((c = getchar()) != ESCAPE) {

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -2,16 +2,85 @@
 #include "commands_registry.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+
+#define MAX_NAME_LEN 32
+#define MAX_STICKERS 64
+#define MAX_STICKER_LEN 2048
+
+typedef struct
+{
+    char name[MAX_NAME_LEN];
+    char sticker[MAX_STICKER_LEN];
+} StickerEntry;
+
+static StickerEntry sticker_array[MAX_STICKERS];
+static size_t sticker_count = 0;
+
+void create_sticker(char *name) {
+    strcpy(sticker_array[sticker_count].sticker, "----------\n---test---\n---aaaa----\n----------");
+    strcpy(sticker_array[sticker_count].name, name);
+    sticker_count++;
+}
+
+char *get_sticker(char *name) {
+    int i;
+    for (i=0; i < sticker_count; i++) {
+        if (strcmp(sticker_array[i].name, name) == 0) {
+            return sticker_array[i].sticker;
+        }
+    }
+    return NULL;
+}
 
 /* Called when the user types /mycommand <args> */
 static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ctx) {
-    lmp_send(ctx->sock, code, args, (uint32_t)strlen(args)); 
+    char *args_copy;
+    char *command;
+    char *sticker;
+    char *name;
+
+    args_copy = (char *)malloc(strlen(args) + 1);
+    strcpy(args_copy, args);
+    command = strtok(args_copy, " ");
+    if (command == NULL) {
+        free(args_copy);
+        printf("No command found!\n");
+        return COMMAND_ERROR;
+    }
+    if (strcmp(command, "create") == 0) {
+        name = strtok(NULL, " ");
+        if (name == NULL) {
+            free(args_copy);
+            printf("No command found!\n");
+            return COMMAND_ERROR;
+        }
+        create_sticker(name);
+        printf("Sticker %s created!", name);
+    } else if (strcmp(command, "send") == 0) {
+        name = strtok(NULL, " ");
+        if (name == NULL) {
+            free(args_copy);
+            printf("No command found!\n");
+            return COMMAND_ERROR;
+        }
+        sticker = get_sticker(name);
+        if (sticker == NULL) {
+            printf("Sticker not found!\n");
+        } else {
+            printf("%s\n", sticker);
+            lmp_send(ctx->sock, code, sticker, (uint32_t)strlen(sticker));
+        }
+    } else {
+        printf("Sticker command %s not found!", command);
+    }
+    free(args_copy);
     return COMMAND_SUCCESS;
 }
 
 /* Called when a LMP_MYCOMMAND packet is received */
 static CommandResult sticker_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx) {
-    printf("[sticker]: %s\n", buf);
+    printf("[%s]: \n%s\n", ctx->peer_nick, buf);
     return COMMAND_SUCCESS;
 }
 

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -1,0 +1,20 @@
+#include "lmp.h"
+#include "commands_registry.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Called when the user types /mycommand <args> */
+static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ctx) {
+    lmp_send(ctx->sock, code, args, (uint32_t)strlen(args)); 
+    return COMMAND_SUCCESS;
+}
+
+/* Called when a LMP_MYCOMMAND packet is received */
+static CommandResult sticker_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx) {
+    printf("[sticker]: %s\n", buf);
+    return COMMAND_SUCCESS;
+}
+
+void sticker_commands_init(void) {
+    register_command(LMP_STICKERS, "sticker", sticker_send, sticker_recv);
+}

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -1,10 +1,11 @@
-#include "lmp.h"
-#include "commands_registry.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <termios.h>
 #include <unistd.h>
+#include "lmp.h"
+#include "commands_registry.h"
+#include "directory_manager.h"
 
 #define MAX_NAME_LEN 32
 #define MAX_STICKERS 64
@@ -19,6 +20,7 @@ typedef struct
 
 static StickerEntry sticker_array[MAX_STICKERS];
 static size_t sticker_count = 0;
+static int history_loaded = 0;
 static struct termios orig_termios;
 
 static void raw_mode_enable(void) {
@@ -88,14 +90,42 @@ char *read_multiline_overlay(void) {
     return buffer;  /* caller must free() */
 }
 
+void load_stickers() {
+    FILE *fp;
+    char *save_file;
+    char line[512];
 
-void create_sticker(char *name) {
-    char *user_sticker;
-    user_sticker = read_multiline_overlay();
-    strcpy(sticker_array[sticker_count].sticker, user_sticker);
-    strcpy(sticker_array[sticker_count].name, name);
-    sticker_count++;
-    printf("Sticker %s created!\n", name);
+    save_file = get_user_directory();
+    strcat(save_file, "saved_stickers.txt");
+    fp = fopen(save_file, "r");
+    if (fp == NULL) return;
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        if (strcmp(line, "<STICKER>\n") == 0) {
+            fgets(line, sizeof(line), fp);
+            line[strcspn(line, "\r\n")] = '\0';
+            strcpy(sticker_array[sticker_count].name, line);
+            fgets(line, sizeof(line), fp);
+            while (strcmp(line, "</STICKER>\n") != 0 && strcmp(line, "</STICKER>") != 0) {
+                strcat(sticker_array[sticker_count].sticker, line);
+                fgets(line, sizeof(line), fp);
+            }
+            sticker_count++;
+        }
+    }
+    fclose(fp);
+}
+
+void save_sticker(StickerEntry entry) {
+    FILE *fp;
+    char *save_file;
+    
+    save_file = get_user_directory();
+    /*strcat(save_file, "saved_stickers.txt");*/
+    fp = fopen(save_file, "a");
+    if (fp == NULL) return;
+    fprintf(fp, "<STICKER>\n%s\n%s\n</STICKER>\n", entry.name, entry.sticker);
+    fclose(fp);
 }
 
 char *get_sticker(char *name) {
@@ -108,12 +138,32 @@ char *get_sticker(char *name) {
     return NULL;
 }
 
+void create_sticker(char *name) {
+    char *user_sticker;
+    if (get_sticker(name) != NULL) {
+        printf("There is already a sticker with name %s!\n", name);
+        return;
+    }
+    user_sticker = read_multiline_overlay();
+    strcpy(sticker_array[sticker_count].sticker, user_sticker);
+    strcpy(sticker_array[sticker_count].name, name);
+    save_sticker(sticker_array[sticker_count]);
+    sticker_count++;
+    printf("Sticker %s created!\n", name);
+}
+
 /* Called when the user types /mycommand <args> */
 static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ctx) {
     char *args_copy;
     char *command;
     char *sticker;
     char *name;
+    int i;
+
+    if (history_loaded == 0) {
+        load_stickers();
+        history_loaded = 1;
+    }
 
     args_copy = (char *)malloc(strlen(args) + 1);
     strcpy(args_copy, args);
@@ -131,7 +181,6 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
             return COMMAND_ERROR;
         }
         create_sticker(name);
-        printf("Sticker %s created!", name);
     } else if (strcmp(command, "send") == 0) {
         name = strtok(NULL, " ");
         if (name == NULL) {
@@ -146,6 +195,20 @@ static CommandResult sticker_send(uint8_t code, const char *args, LMPContext *ct
             printf("%s\n", sticker);
             lmp_send(ctx->sock, code, sticker, (uint32_t)strlen(sticker));
         }
+    } else if (strcmp(command, "list") == 0) {
+        printf("Stickers saved:\n");
+        for (i = 0; i < sticker_count; i++) {
+            printf("%s\n", sticker_array[i].name);
+        }
+    } else if (strcmp(command, "preview") == 0) {
+        name = strtok(NULL, " ");
+        if (name == NULL) {
+            free(args_copy);
+            printf("No command found!\n");
+            return COMMAND_ERROR;
+        }
+        sticker = get_sticker(name);
+        printf("%s\n", sticker);
     } else {
         printf("Sticker command %s not found!", command);
     }

--- a/sticker_commands.c
+++ b/sticker_commands.c
@@ -150,6 +150,7 @@ void create_sticker(char *name) {
     save_sticker(sticker_array[sticker_count]);
     sticker_count++;
     printf("Sticker %s created!\n", name);
+    free(user_sticker);
 }
 
 /* Called when the user types /mycommand <args> */

--- a/sticker_commands.h
+++ b/sticker_commands.h
@@ -1,0 +1,7 @@
+/* sticker_commands.h */
+#ifndef STICKER_COMMANDS_H
+#define STICKER_COMMANDS_H
+
+void sticker_commands_init(void);
+
+#endif


### PR DESCRIPTION
### Stickers
ASCII-art stickers can be sent using the command `/sticker`. Sticker operations are as follows:
<ul>
    <li>Create</li>
    <li>Send</li>
    <li>List</li>
    <li>Preview</li>
</ul>
Stickers previously created are saved and can be retrieved after by logging back in as the user that created them.

#### Feature: Create
Creates a sticker with the specified name.
```
/sticker create <sticker_name>
```
This command opens up an editor where user can edit the sticker. Press the `ESC` key to close the editor and save the sticker.

#### Feature: Send
Sends the sticker to the other users in the chat.
```
/sticker send <sticker_name>
```

#### Feature: List
Lists all stickers created by the current user.
```
/sticker list
```

#### Feature: Preview
Previews a particular sticker in user's own terminal without sending it to other users in chat.
```
/sticker preview <sticker_name>
```