### PR TITLE
handle message send from user to group server

### DIFF
--- a/commands_registry.c
+++ b/commands_registry.c
@@ -2,6 +2,7 @@
 #include "base_commands.h"
 /* Add #include directives for any other required headers */
 #include "meow_commands.h"
+#include "group_commands.h"
 
 void init_commands(void)
 {
@@ -9,4 +10,5 @@ void init_commands(void)
 
     /* Append any additional command initializations here */
     meow_commands_init();
+    group_commands_init();
 }

--- a/commands_registry.h
+++ b/commands_registry.h
@@ -10,7 +10,8 @@ typedef enum
     LMP_ACK = 0x03,
     LMP_MEOW = 0x10,
     LMP_ERROR = 0xFF,
-    LMP_UID = 0x04
+    LMP_UID = 0x04,
+    LMP_GRP_OBJ = 0x80
 } LMPCode;
 
 void init_commands(void);

--- a/group_commands.c
+++ b/group_commands.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <string.h>
+#include "lmp.h"
+#include "group.h"
+#include "commands_registry.h"
+
+extern Group current_group;
+extern Group user_group;
+
+/* GRP */
+CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx)
+{
+    char *payload = (char *)&current_group;
+    uint32_t payload_len = sizeof(current_group);
+    if (lmp_send(ctx->sock, code, payload, payload_len) < 0)
+        return COMMAND_ERROR;
+    return COMMAND_SUCCESS;
+}
+
+static CommandResult grp_obj_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx)
+{
+    user_group = *(Group *)buf;
+    printf("[Server]: New group saved. Members: %d\n", user_group.member_count);
+    return COMMAND_SUCCESS;
+}
+
+void group_commands_init(void)
+{
+    register_command(LMP_GRP_OBJ, "grpobj", grp_obj_send, grp_obj_recv);
+}

--- a/group_commands.h
+++ b/group_commands.h
@@ -1,0 +1,10 @@
+/* group_commands.h */
+#ifndef GROUP_COMMANDS_H
+#define GROUP_COMMANDS_H
+#include "lmp.h"
+
+CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx);
+
+void group_commands_init(void);
+
+#endif /* GROUP_COMMANDS_H */

--- a/group_comms.h
+++ b/group_comms.h
@@ -17,4 +17,17 @@ typedef struct
     GroupInfo info;
 } GroupDiscoveryReplyMsg;
 
+typedef struct
+{
+    int sock; /* Server sock */
+    char my_nick[NICKNAME_MAX_LEN];
+    char group_ip[64]; /* LMPContext::peer_ip */
+    char my_uid[9];
+    char group_uid[9];   /* LMPContext::peer_uid */
+    char group_dir[256]; /* LMPContext::peer_dir */
+    char history_path[256];
+    int history_loaded;
+    Group group;
+} GroupContext;
+
 #endif /* GROUP_H */

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -10,6 +10,7 @@
 #include <poll.h>
 #include "group.h"
 #include "group_comms.h"
+#include "group_commands.h"
 #include "group_server_comms.h"
 #include "lmp.h"
 #include "commands_registry.h"
@@ -202,6 +203,8 @@ void add_to_global_connections(GroupMember member, int user_sock)
     group_connections[connection_count].tcp_socket = user_sock;
     group_connections[connection_count].member = member;
     connection_count++;
+    current_group.members[current_group.member_count] = member;
+    current_group.member_count++;
     return;
 }
 
@@ -215,6 +218,8 @@ int send_welcome_message(GroupMember member, int user_sock)
     char response[1024];
     const char *nickname;
     const char *group_name;
+    LMPContext ctx;
+    ctx.sock = user_sock;
     nickname = (member.nickname[0] != '\0') ? member.nickname : "Unknown";
     group_name = (current_group.info.group_name[0] != '\0') ? current_group.info.group_name : "Unknown Group";
 
@@ -243,6 +248,10 @@ int send_welcome_message(GroupMember member, int user_sock)
     }
 
     if ((lmp_send(user_sock, LMP_MSG, response, (uint32_t)strlen(response))) < 0)
+        return -1;
+
+    printf("Current number of members: %d\n", current_group.member_count);
+    if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
         return -1;
     return 0;
 }
@@ -325,9 +334,9 @@ void handle_client_data(int listener, int *fd_count,
     char buf[4096];
     uint32_t len;
 
-    int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
-
+    int sender_connection_index;
     int sender_fd = pfds[*pfd_i].fd;
+    int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
 
     if (recv_status < 0)
     { /* Got error or connection closed by client */
@@ -354,7 +363,7 @@ void handle_client_data(int listener, int *fd_count,
         printf("[Server] recv from fd %d: %.*s\n", sender_fd,
                len, buf);
         /* Send to everyone! */
-        int sender_connection_index = sender_fd - 1;
+        sender_connection_index = sender_fd - 1;
         for (j = 0; j < *fd_count; j++)
         {
             int dest_fd = pfds[j].fd;

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -298,6 +298,22 @@ void handle_new_connection(int listener, int *fd_count,
     }
 }
 
+int group_lmp_send(int fd, uint8_t type, const char *payload, uint32_t len, int sender)
+{
+    lmp_header_t hdr;
+    hdr.magic[0] = LMP_MAGIC_0;
+    hdr.magic[1] = LMP_MAGIC_1;
+    hdr.type = type;
+    hdr.reserved = (uint8_t)sender;
+    hdr.payload_len = htonl(len);
+
+    if (send(fd, &hdr, sizeof(hdr), 0) < 0)
+        return -1;
+    if (len > 0 && send(fd, payload, len, 0) < 0)
+        return -1;
+    return 0;
+}
+
 /*
  * Handle regular client data or client hangups.
  */
@@ -338,14 +354,14 @@ void handle_client_data(int listener, int *fd_count,
         printf("[Server] recv from fd %d: %.*s\n", sender_fd,
                len, buf);
         /* Send to everyone! */
+        int sender_connection_index = sender_fd - 1;
         for (j = 0; j < *fd_count; j++)
         {
             int dest_fd = pfds[j].fd;
-
             /* Except the listener and ourselves */
             if (dest_fd != listener && dest_fd != sender_fd)
             {
-                if (lmp_send(dest_fd, type, buf, len) == -1)
+                if (group_lmp_send(dest_fd, type, buf, len, sender_connection_index) == -1)
                 {
                     perror("send");
                 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -11,6 +11,7 @@
 #include "group.h"
 #include "group_comms.h"
 #include "group_server_comms.h"
+#include "lmp.h"
 
 GroupConnection group_connections[MAX_GROUP_CONNECTIONS];
 Group current_group;
@@ -303,21 +304,27 @@ void handle_client_data(int listener, int *fd_count,
                         struct pollfd *pfds, int *pfd_i)
 {
     int j;
-    char buf[256]; /* Buffer for client data */
+    uint8_t type;
+    char buf[4096];
+    uint32_t len;
 
+    /*
     int nbytes = recv(pfds[*pfd_i].fd, buf, sizeof buf, 0);
+    */
+    int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
 
     int sender_fd = pfds[*pfd_i].fd;
 
-    if (nbytes <= 0)
+    if (recv_status < 0)
     { /* Got error or connection closed by client */
-        if (nbytes == 0)
+        if (recv_status == -2)
         {
             /* Connection closed */
             printf("[Server] socket %d hung up\n", sender_fd);
         }
         else
         {
+            fprintf(stderr, "recv_status: %d", recv_status);
             perror("recv");
         }
 
@@ -331,7 +338,7 @@ void handle_client_data(int listener, int *fd_count,
     else
     { /* We got some good data from a client */
         printf("[Server] recv from fd %d: %.*s\n", sender_fd,
-               nbytes, buf);
+               len, buf);
         /* Send to everyone! */
         for (j = 0; j < *fd_count; j++)
         {
@@ -340,7 +347,7 @@ void handle_client_data(int listener, int *fd_count,
             /* Except the listener and ourselves */
             if (dest_fd != listener && dest_fd != sender_fd)
             {
-                if (send(dest_fd, buf, nbytes, 0) == -1)
+                if (send(dest_fd, buf, len, 0) == -1)
                 {
                     perror("send");
                 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -12,6 +12,7 @@
 #include "group_comms.h"
 #include "group_server_comms.h"
 #include "lmp.h"
+#include "commands_registry.h"
 
 GroupConnection group_connections[MAX_GROUP_CONNECTIONS];
 Group current_group;
@@ -241,7 +242,7 @@ int send_welcome_message(GroupMember member, int user_sock)
         append_text(response, sizeof(response), ")\n");
     }
 
-    if ((send(user_sock, response, strlen(response), 0)) < 0)
+    if ((lmp_send(user_sock, LMP_MSG, response, (uint32_t)strlen(response))) < 0)
         return -1;
     return 0;
 }
@@ -321,6 +322,7 @@ void handle_client_data(int listener, int *fd_count,
         }
         else
         {
+            fprintf(stderr, "recv_status = %d\n", recv_status);
             perror("recv");
         }
 
@@ -343,7 +345,7 @@ void handle_client_data(int listener, int *fd_count,
             /* Except the listener and ourselves */
             if (dest_fd != listener && dest_fd != sender_fd)
             {
-                if (send(dest_fd, buf, len, 0) == -1)
+                if (lmp_send(dest_fd, type, buf, len) == -1)
                 {
                     perror("send");
                 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <poll.h>
 #include "group.h"
 #include "group_comms.h"
 #include "group_server_comms.h"
@@ -162,38 +163,56 @@ void group_server_UDP_reply(GroupInfo *group_info)
     close(sock);
 }
 
-void *handle_user_connection(void *arg)
+/*
+ * Add a new file descriptor to the set.
+ */
+void add_to_pfds(struct pollfd **pfds, int newfd, int *fd_count,
+                 int *fd_size)
 {
-    char response[1024];
-    int user_sock = *((int *)arg);
-    GroupMember member = {0}; /* Initialize member with zeros */
-    int i;
-    const char *nickname;
-    const char *group_name;
-
-    free(arg);
-
-    /* Add user_sock to group_connections */
-    group_connections[connection_count - 1].tcp_socket = user_sock;
-    /* Note: The UID will be set later when the user sends their UID */
-
-    /* Initial receive for UID and nickname if have */
-    recv(user_sock, (void *)&member, sizeof(member) - 1, 0);
-
-    /* Add user to group connections list */
-    for (i = 0; i < connection_count; i++)
+    /* If we don't have room, add more space in the pfds array */
+    if (*fd_count == *fd_size)
     {
-        if (group_connections[i].tcp_socket == user_sock)
-        {
-            group_connections[i].member = member;
-            break;
-        }
+        *fd_size *= 2; /* Double it */
+        *pfds = realloc(*pfds, sizeof(**pfds) * (*fd_size));
     }
 
-    /* Print to terminal */
-    printf("[Group TCP] User connected: %s (UID: %s)\n", member.nickname, member.uid);
+    (*pfds)[*fd_count].fd = newfd;
+    (*pfds)[*fd_count].events = POLLIN; /* Check ready-to-read */
+    (*pfds)[*fd_count].revents = 0;
 
-    /* Prepare welcome message */
+    (*fd_count)++;
+}
+
+/*
+ * Remove a file descriptor at a given index from the set.
+ */
+void del_from_pfds(struct pollfd pfds[], int i, int *fd_count)
+{
+    /* Copy the one from the end over this one */
+    pfds[i] = pfds[*fd_count - 1];
+
+    (*fd_count)--;
+}
+
+/* Add member to global connections */
+void add_to_global_connections(GroupMember member, int user_sock)
+{
+    group_connections[connection_count].tcp_socket = user_sock;
+    group_connections[connection_count].member = member;
+    connection_count++;
+    return;
+}
+
+/*
+ * Send welcome message to newest connection
+ * Returns success (0) or fail (1)
+ */
+int send_welcome_message(GroupMember member, int user_sock)
+{
+    int i;
+    char response[1024];
+    const char *nickname;
+    const char *group_name;
     nickname = (member.nickname[0] != '\0') ? member.nickname : "Unknown";
     group_name = (current_group.info.group_name[0] != '\0') ? current_group.info.group_name : "Unknown Group";
 
@@ -221,15 +240,155 @@ void *handle_user_connection(void *arg)
         append_text(response, sizeof(response), ")\n");
     }
 
-    send(user_sock, response, strlen(response), 0);
-
-    /* TODO: Handle when user disconnects */
-    sleep(1000); /* Placeholder to keep the connection open for testing */
-    close(user_sock);
-    return NULL;
+    if ((send(user_sock, response, strlen(response), 0)) < 0)
+        return -1;
+    return 0;
 }
 
-int group_server_TCP_listen()
+/*
+ * Handle incoming connections.
+ */
+void handle_new_connection(int listener, int *fd_count,
+                           int *fd_size, struct pollfd **pfds)
+{
+    struct sockaddr_in remoteaddr; /* Client address */
+    socklen_t addrlen;
+    int newfd;                /* Newly accept()ed socket descriptor */
+    GroupMember member = {0}; /* Initialize member with zeros */
+
+    addrlen = sizeof remoteaddr;
+    newfd = accept(listener, (struct sockaddr *)&remoteaddr,
+                   &addrlen);
+
+    if (newfd == -1)
+    {
+        perror("accept");
+        return;
+    }
+
+    /* Continue if accept is successful */
+
+    if (connection_count >= MAX_GROUP_CONNECTIONS)
+    {
+        fprintf(stderr, "Maximum connection limit reached. Cannot add more connections.\n");
+        close(newfd);
+        return;
+    }
+
+    /* Continue if both accept is successful and
+        connection limit has not been reached */
+
+    add_to_pfds(pfds, newfd, fd_count, fd_size);
+
+    /* Receive member info (UID and nickname) */
+    recv(newfd, (void *)&member, sizeof(member), 0);
+
+    add_to_global_connections(member, newfd);
+
+    printf("[Group TCP] Accepted connection from %s\n",
+           inet_ntoa(remoteaddr.sin_addr));
+
+    if (send_welcome_message(member, newfd) != 0)
+    {
+        perror("send");
+        close(newfd);
+        return;
+    }
+}
+
+/*
+ * Handle regular client data or client hangups.
+ */
+void handle_client_data(int listener, int *fd_count,
+                        struct pollfd *pfds, int *pfd_i)
+{
+    int j;
+    char buf[256]; /* Buffer for client data */
+
+    int nbytes = recv(pfds[*pfd_i].fd, buf, sizeof buf, 0);
+
+    int sender_fd = pfds[*pfd_i].fd;
+
+    if (nbytes <= 0)
+    { /* Got error or connection closed by client */
+        if (nbytes == 0)
+        {
+            /* Connection closed */
+            printf("[Server] socket %d hung up\n", sender_fd);
+        }
+        else
+        {
+            perror("recv");
+        }
+
+        close(pfds[*pfd_i].fd); /* Bye! */
+
+        del_from_pfds(pfds, *pfd_i, fd_count);
+
+        /* reexamine the slot we just deleted */
+        (*pfd_i)--;
+    }
+    else
+    { /* We got some good data from a client */
+        printf("[Server] recv from fd %d: %.*s\n", sender_fd,
+               nbytes, buf);
+        /* Send to everyone! */
+        for (j = 0; j < *fd_count; j++)
+        {
+            int dest_fd = pfds[j].fd;
+
+            /* Except the listener and ourselves */
+            if (dest_fd != listener && dest_fd != sender_fd)
+            {
+                if (send(dest_fd, buf, nbytes, 0) == -1)
+                {
+                    perror("send");
+                }
+            }
+        }
+    }
+}
+
+/*
+ * Process all existing connections.
+ */
+void process_connections(int listener, int *fd_count, int *fd_size,
+                         struct pollfd **pfds)
+{
+    int i;
+    for (i = 0; i < *fd_count; i++)
+    {
+
+        /* Check if someone's ready to read */
+        if ((*pfds)[i].revents & (POLLIN | POLLHUP))
+        {
+            /* We got one!! */
+
+            if ((*pfds)[i].fd == listener)
+            {
+                /* If we're the listener, it's a new connection */
+                handle_new_connection(listener, fd_count, fd_size,
+                                      pfds);
+            }
+            else
+            {
+                /* Otherwise we're just a regular client */
+                handle_client_data(listener, fd_count, *pfds, &i);
+            }
+        }
+    }
+}
+
+void close_all_socks(struct pollfd *pfds, int *fd_count)
+{
+    while ((*fd_count) > 0)
+    {
+        close(pfds[*fd_count - 1].fd);
+        del_from_pfds(pfds, *fd_count - 1, fd_count);
+    }
+}
+
+int get_listener_socket()
 {
     int sock, reuse = 1;
     struct sockaddr_in server_addr;
@@ -243,77 +402,72 @@ int group_server_TCP_listen()
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
     {
         perror("socket failed");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     /* Socket Option Reuse Address */
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
     {
         perror("setsockopt SO_REUSEADDR failed");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     /* Bind to port */
     if (bind(sock, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0)
     {
         perror("bind failed");
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
-    if (listen(sock, 5) < 0)
+    if (listen(sock, 5) < 0) /* at most 5 requests should come in at one time... */
     {
         perror("listen failed");
+        return -1;
+    }
+
+    return sock;
+}
+
+int group_server_TCP_listen()
+{
+    int sock;
+
+    int fd_size = MAX_GROUP_CONNECTIONS;
+    int fd_count = 0;
+    struct pollfd *pfds = malloc(sizeof *pfds * fd_size);
+
+    /* Create Listener Socket */
+    sock = get_listener_socket();
+    if (sock < 0)
+    {
+        fprintf(stderr, "error getting listening socket\n");
         exit(EXIT_FAILURE);
     }
 
+    /* Add the listener to set; */
+    /* Report ready to read on incoming connection */
+    pfds[0].fd = sock;
+    pfds[0].events = POLLIN;
+
+    fd_count = 1; /* For the listener */
+
     printf("[Group TCP] Awaiting connection request\n");
-    /* For each accepted connection, spawn a new thread to handle the user */
-    while (1)
+    for (;;)
     {
-        struct sockaddr_in user_addr;
-        socklen_t addr_len = sizeof(user_addr);
-        int user_sock = accept(sock, (struct sockaddr *)&user_addr, &addr_len);
-        pthread_t user_thread;
-        int *user_sock_ptr;
-        int create_status;
-        if (user_sock < 0)
+        int poll_count = poll(pfds, fd_count, -1);
+
+        if (poll_count == -1)
         {
-            perror("accept failed");
-            continue;
+            perror("poll");
+            exit(1);
         }
 
-        /* Create user thread */
-        if (connection_count < MAX_GROUP_CONNECTIONS)
-        {
-            user_sock_ptr = (int *)malloc(sizeof(int));
-            if (user_sock_ptr == NULL)
-            {
-                perror("malloc failed");
-                close(user_sock);
-                continue;
-            }
-
-            *user_sock_ptr = user_sock;
-            create_status = pthread_create(&user_thread, NULL, handle_user_connection, (void *)user_sock_ptr);
-            if (create_status != 0)
-            {
-                fprintf(stderr, "pthread_create failed: %s\n", strerror(create_status));
-                free(user_sock_ptr);
-                close(user_sock);
-                continue;
-            }
-
-            pthread_detach(user_thread);
-            connection_count++;
-        }
-        else
-        {
-            fprintf(stderr, "Maximum connection limit reached. Cannot add more connections.\n");
-            close(user_sock);
-        }
-
-        printf("[Group TCP] Accepted connection from %s\n", inet_ntoa(user_addr.sin_addr));
+        /* Run through connections looking for data to read */
+        process_connections(sock, &fd_count, &fd_size, &pfds);
     }
+
+    close_all_socks(pfds, &fd_count); /* temp function until handle_client_data is up */
     close(sock);
+    free(pfds);
     return 0;
 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -256,6 +256,29 @@ int send_welcome_message(GroupMember member, int user_sock)
     return 0;
 }
 
+int send_new_group_to_users(int listener, int sender_fd,
+                            int *fd_count, struct pollfd **pfds)
+{
+    int i;
+    LMPContext ctx;
+
+    for (i = 0; i < *fd_count; i++)
+    {
+        int dest_fd = (*pfds)[i].fd;
+        ctx.sock = dest_fd;
+        /* Except the listener and ourselves */
+        if (dest_fd != listener && dest_fd != sender_fd)
+        {
+            if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
+            {
+                perror("grp_obj_send");
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
 /*
  * Handle incoming connections.
  */
@@ -301,7 +324,14 @@ void handle_new_connection(int listener, int *fd_count,
 
     if (send_welcome_message(member, newfd) != 0)
     {
-        perror("send");
+        perror("send_welcome_message");
+        close(newfd);
+        return;
+    }
+
+    if (send_new_group_to_users(listener, newfd, fd_count, pfds) != 0)
+    {
+        perror("send_new_group_to_users");
         close(newfd);
         return;
     }
@@ -363,7 +393,7 @@ void handle_client_data(int listener, int *fd_count,
         printf("[Server] recv from fd %d: %.*s\n", sender_fd,
                len, buf);
         /* Send to everyone! */
-        sender_connection_index = sender_fd - 1;
+        sender_connection_index = *pfd_i - 1; /* pollfd have one extra listener */
         for (j = 0; j < *fd_count; j++)
         {
             int dest_fd = pfds[j].fd;

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -308,9 +308,6 @@ void handle_client_data(int listener, int *fd_count,
     char buf[4096];
     uint32_t len;
 
-    /*
-    int nbytes = recv(pfds[*pfd_i].fd, buf, sizeof buf, 0);
-    */
     int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
 
     int sender_fd = pfds[*pfd_i].fd;
@@ -324,7 +321,6 @@ void handle_client_data(int listener, int *fd_count,
         }
         else
         {
-            fprintf(stderr, "recv_status: %d", recv_status);
             perror("recv");
         }
 

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -5,10 +5,14 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <pthread.h>
 #include "uid.h"
 #include "group.h"
 #include "group_comms.h"
 #include "group_user_comms.h"
+#include "lmp.h"
+#include "commands_registry.h"
+#include "directory_manager.h"
 
 /* For User */
 /* Parameters: Pointer to store the server's address and reply message */
@@ -111,4 +115,118 @@ int user_TCP_to_group_server(struct sockaddr_in *server_addr)
     }
 
     return tcp_sock;
+}
+
+/* Middleware function to handle chat functionality */
+/* int sock: socket file descriptor */
+/* const char *role: role of the user (e.g., "server", "client") */
+void group_chat(int sock, const char *role)
+{
+    char peer_ip[INET_ADDRSTRLEN];
+
+    (void)role;
+
+    if (get_peer_ip(sock, peer_ip, sizeof(peer_ip)) == 0)
+        printf("Connected from IP: %s\n", peer_ip);
+    else
+        strncpy(peer_ip, "unknown_peer", sizeof(peer_ip) - 1);
+
+    peer_ip[sizeof(peer_ip) - 1] = '\0';
+
+    init_commands(); /* Initialize all commands */
+    chat_loop_user(sock, peer_ip, "");
+}
+
+void chat_loop_user(int sock, const char *server_ip, const char *history_path)
+{
+    pthread_t recv_thread;
+    char line[1024];
+    LMPContext ctx;
+    FILE *fp;
+    ctx.sock = sock;
+
+    strncpy(ctx.my_nick, "You", sizeof(ctx.my_nick) - 1);
+    /* strncpy(ctx.peer_nick, "Peer", sizeof(ctx.peer_nick) - 1); */
+    ctx.my_nick[sizeof(ctx.my_nick) - 1] = '\0';
+    /* ctx.peer_nick[sizeof(ctx.peer_nick) - 1] = '\0'; */
+
+    /* Load saved nickname if it exists */
+    fp = open_file_in_user_directory("nick.txt", "r");
+    if (fp != NULL)
+    {
+        fscanf(fp, "%63s", ctx.my_nick);
+        fclose(fp);
+    }
+
+    strncpy(ctx.peer_ip, server_ip ? server_ip : "unknown_peer", sizeof(ctx.peer_ip) - 1);
+    ctx.peer_ip[sizeof(ctx.peer_ip) - 1] = '\0';
+
+    strncpy(ctx.history_path, history_path ? history_path : "", sizeof(ctx.history_path) - 1);
+    ctx.history_path[sizeof(ctx.history_path) - 1] = '\0';
+
+    /*ctx.peer_uid[0] = '\0';*/
+    ctx.history_loaded = 0;
+
+    strncpy(ctx.my_uid, get_uid(), sizeof(ctx.my_uid) - 1);
+    ctx.my_uid[sizeof(ctx.my_uid) - 1] = '\0';
+
+    pthread_create(&recv_thread, NULL, receiver, &ctx);
+
+    /* send GroupMember information here */
+
+    while (1)
+    {
+        print_prompt(&ctx);
+        if (!fgets(line, sizeof(line), stdin))
+            break;
+        strip_newline(line);
+
+        if (line[0] == '/')
+        {
+            switch (dispatch_send(line + 1, &ctx))
+            {
+            case COMMAND_SUCCESS:
+                break;
+            case COMMAND_ERROR:
+                printf("Error executing '%s'\n", line);
+                break;
+            case COMMAND_UNRECOGNIZED:
+                printf("Unrecognized command '%s'\n", line);
+                break;
+            }
+        }
+        else
+        {
+            if (lmp_send(ctx.sock, LMP_MSG, line, (uint32_t)strlen(line)) == 0)
+                lmp_history_append(&ctx, ctx.my_nick, line);
+        }
+    }
+
+    shutdown(sock, SHUT_WR);
+    pthread_join(recv_thread, NULL);
+}
+
+static void *receiver(void *arg)
+{
+    LMPContext *ctx = (LMPContext *)arg;
+    uint8_t type;
+    char buf[4096];
+    uint32_t len;
+
+    int status_code;
+
+    while (1)
+    {
+        status_code = lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len);
+        if (status_code != 0)
+            break;
+        printf("\r\033[K");
+        if (dispatch_recv(type, buf, len, ctx) == COMMAND_UNRECOGNIZED)
+            printf("[warning]: unrecognized message type 0x%02X\n", type);
+        print_prompt(ctx);
+    }
+
+    fprintf(stderr, "lmp_recv: status %d\n", status_code);
+    printf("*** Peer disconnected.\n");
+    return NULL;
 }

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -14,6 +14,7 @@
 #include "commands_registry.h"
 #include "directory_manager.h"
 
+Group user_group;
 /* For User */
 /* Parameters: Pointer to store the server's address and reply message */
 /* Returns: 1 if server found, 0 otherwise */
@@ -137,6 +138,31 @@ void group_chat(int sock, const char *role)
     chat_loop_user(sock, peer_ip, "");
 }
 
+static void *receiver(void *arg)
+{
+    LMPContext *ctx = (LMPContext *)arg;
+    uint8_t type;
+    char buf[4096];
+    uint32_t len;
+
+    int status_code;
+
+    while (1)
+    {
+        status_code = lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len);
+        if (status_code != 0)
+            break;
+        printf("\r\033[K");
+        if (dispatch_recv(type, buf, len, ctx) == COMMAND_UNRECOGNIZED)
+            printf("[warning]: unrecognized message type 0x%02X\n", type);
+        print_prompt(ctx);
+    }
+
+    fprintf(stderr, "lmp_recv: status %d\n", status_code);
+    printf("*** Peer disconnected.\n");
+    return NULL;
+}
+
 void chat_loop_user(int sock, const char *server_ip, const char *history_path)
 {
     pthread_t recv_thread;
@@ -204,29 +230,4 @@ void chat_loop_user(int sock, const char *server_ip, const char *history_path)
 
     shutdown(sock, SHUT_WR);
     pthread_join(recv_thread, NULL);
-}
-
-static void *receiver(void *arg)
-{
-    LMPContext *ctx = (LMPContext *)arg;
-    uint8_t type;
-    char buf[4096];
-    uint32_t len;
-
-    int status_code;
-
-    while (1)
-    {
-        status_code = lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len);
-        if (status_code != 0)
-            break;
-        printf("\r\033[K");
-        if (dispatch_recv(type, buf, len, ctx) == COMMAND_UNRECOGNIZED)
-            printf("[warning]: unrecognized message type 0x%02X\n", type);
-        print_prompt(ctx);
-    }
-
-    fprintf(stderr, "lmp_recv: status %d\n", status_code);
-    printf("*** Peer disconnected.\n");
-    return NULL;
 }

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -138,18 +138,53 @@ void group_chat(int sock, const char *role)
     chat_loop_user(sock, peer_ip, "");
 }
 
+int group_lmp_recv(int fd, uint8_t *type_out, char *buf, uint32_t bufsize, uint32_t *len_out, int *sender_out)
+{
+    lmp_header_t hdr;
+    uint32_t plen;
+
+    int header_bytes = read_all(fd, &hdr, sizeof(hdr));
+    if (header_bytes < 0)
+        return -1;
+    if (header_bytes == 0)
+        return -2; /* temp code for EOF (connection closed)*/
+
+    /* Checking valid header */
+    if (hdr.magic[0] != LMP_MAGIC_0 || hdr.magic[1] != LMP_MAGIC_1 || header_bytes < sizeof hdr)
+        return -3;
+
+    plen = ntohl(hdr.payload_len);
+    if (plen >= bufsize)
+        return -4;
+
+    if (plen > 0 && read_all(fd, buf, plen) <= 0)
+        return -5;
+    buf[plen] = '\0';
+
+    *type_out = hdr.type;
+    *len_out = plen;
+    *sender_out = hdr.reserved;
+    return 0;
+}
+
 static void *receiver(void *arg)
 {
     LMPContext *ctx = (LMPContext *)arg;
     uint8_t type;
     char buf[4096];
     uint32_t len;
+    int sender_i;
 
     int status_code;
 
     while (1)
     {
-        status_code = lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len);
+        status_code = group_lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len, &sender_i);
+
+        /* Amend ctx for dispatch_recv function */
+        memcpy(ctx->peer_nick, &user_group.members[sender_i].nickname, sizeof(char) * NICKNAME_MAX_LEN);
+        memcpy(ctx->peer_uid, &user_group.members[sender_i].uid, sizeof(char) * (UID_LENGTH + 1));
+
         if (status_code != 0)
             break;
         printf("\r\033[K");

--- a/group_user_comms.h
+++ b/group_user_comms.h
@@ -7,4 +7,7 @@
 int user_UDP_to_group_server(struct sockaddr_in *server_addr, GroupDiscoveryReplyMsg *reply);
 int user_TCP_to_group_server(struct sockaddr_in *server_addr);
 
+void group_chat(int sock, const char *role);
+void chat_loop_user(int sock, const char *server_ip, const char *history_path);
+
 #endif /* GROUP_USER_COMMS_H */

--- a/lmp.c
+++ b/lmp.c
@@ -137,19 +137,29 @@ CommandResult dispatch_recv(uint8_t code, const char *buf, uint32_t len, LMPCont
     return COMMAND_UNRECOGNIZED;
 }
 
-static int read_all(int fd, void *buf, size_t n)
+static ssize_t read_all(int fd, void *buf, size_t n)
 {
     size_t total = 0;
     char *p = (char *)buf;
     ssize_t r;
+
     while (total < n)
     {
         r = read(fd, p + total, n - total);
-        if (r <= 0)
-            return -1;
+        if (r < 0)
+        {
+            if (errno == EINTR)
+                continue; /* retry on interrupt */
+            return -1;    /* real error */
+        }
+        if (r == 0)
+        {
+            /* EOF - return number of bytes actually read */
+            return (ssize_t)total;
+        }
         total += (size_t)r;
     }
-    return 0;
+    return (ssize_t)total;
 }
 
 static void print_prompt(LMPContext *ctx)
@@ -419,16 +429,21 @@ int lmp_recv(int fd, uint8_t *type_out, char *buf, uint32_t bufsize, uint32_t *l
     lmp_header_t hdr;
     uint32_t plen;
 
-    if (read_all(fd, &hdr, sizeof(hdr)) < 0)
+    int header_bytes = read_all(fd, &hdr, sizeof(hdr));
+    if (header_bytes < 0)
         return -1;
-    if (hdr.magic[0] != LMP_MAGIC_0 || hdr.magic[1] != LMP_MAGIC_1)
+    if (header_bytes == 0)
+        return -2; /* temp code for EOF (connection closed)*/
+
+    /* Checking valid header */
+    if (hdr.magic[0] != LMP_MAGIC_0 || hdr.magic[1] != LMP_MAGIC_1 || header_bytes < sizeof hdr)
         return -1;
 
     plen = ntohl(hdr.payload_len);
     if (plen >= bufsize)
         return -1;
 
-    if (plen > 0 && read_all(fd, buf, plen) < 0)
+    if (plen > 0 && read_all(fd, buf, plen) <= 0)
         return -1;
     buf[plen] = '\0';
 

--- a/lmp.c
+++ b/lmp.c
@@ -182,14 +182,20 @@ static void *receiver(void *arg)
     char buf[4096];
     uint32_t len;
 
-    while (lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len) == 0)
+    int status_code;
+
+    while (1)
     {
+        status_code = lmp_recv(ctx->sock, &type, buf, sizeof(buf), &len);
+        if (status_code != 0)
+            break;
         printf("\r\033[K");
         if (dispatch_recv(type, buf, len, ctx) == COMMAND_UNRECOGNIZED)
             printf("[warning]: unrecognized message type 0x%02X\n", type);
         print_prompt(ctx);
     }
 
+    fprintf(stderr, "lmp_recv: status %d\n", status_code);
     printf("*** Peer disconnected.\n");
     return NULL;
 }
@@ -330,7 +336,10 @@ void chat(int sock, const char *role)
     peer_ip[sizeof(peer_ip) - 1] = '\0';
 
     init_commands(); /* Initialize all commands */
-    chat_loop(sock, peer_ip, "");
+    if (strcmp(role, "user") == 0)
+        chat_loop_user(sock, peer_ip, "");
+    else
+        chat_loop(sock, peer_ip, "");
 }
 
 /* Actual chat loop implementation */
@@ -409,6 +418,75 @@ void chat_loop(int sock, const char *peer_ip, const char *history_path)
     pthread_join(recv_thread, NULL);
 }
 
+void chat_loop_user(int sock, const char *server_ip, const char *history_path)
+{
+    pthread_t recv_thread;
+    char line[1024];
+    LMPContext ctx;
+    FILE *fp;
+    ctx.sock = sock;
+
+    strncpy(ctx.my_nick, "You", sizeof(ctx.my_nick) - 1);
+    strncpy(ctx.peer_nick, "Peer", sizeof(ctx.peer_nick) - 1);
+    ctx.my_nick[sizeof(ctx.my_nick) - 1] = '\0';
+    ctx.peer_nick[sizeof(ctx.peer_nick) - 1] = '\0';
+
+    /* Load saved nickname if it exists */
+    fp = open_file_in_user_directory("nick.txt", "r");
+    if (fp != NULL)
+    {
+        fscanf(fp, "%63s", ctx.my_nick);
+        fclose(fp);
+    }
+
+    strncpy(ctx.peer_ip, server_ip ? server_ip : "unknown_peer", sizeof(ctx.peer_ip) - 1);
+    ctx.peer_ip[sizeof(ctx.peer_ip) - 1] = '\0';
+
+    strncpy(ctx.history_path, history_path ? history_path : "", sizeof(ctx.history_path) - 1);
+    ctx.history_path[sizeof(ctx.history_path) - 1] = '\0';
+
+    ctx.peer_uid[0] = '\0';
+    ctx.history_loaded = 0;
+
+    strncpy(ctx.my_uid, get_uid(), sizeof(ctx.my_uid) - 1);
+    ctx.my_uid[sizeof(ctx.my_uid) - 1] = '\0';
+
+    pthread_create(&recv_thread, NULL, receiver, &ctx);
+
+    /* send GroupMember information here */
+
+    while (1)
+    {
+        print_prompt(&ctx);
+        if (!fgets(line, sizeof(line), stdin))
+            break;
+        strip_newline(line);
+
+        if (line[0] == '/')
+        {
+            switch (dispatch_send(line + 1, &ctx))
+            {
+            case COMMAND_SUCCESS:
+                break;
+            case COMMAND_ERROR:
+                printf("Error executing '%s'\n", line);
+                break;
+            case COMMAND_UNRECOGNIZED:
+                printf("Unrecognized command '%s'\n", line);
+                break;
+            }
+        }
+        else
+        {
+            if (lmp_send(ctx.sock, LMP_MSG, line, (uint32_t)strlen(line)) == 0)
+                lmp_history_append(&ctx, ctx.my_nick, line);
+        }
+    }
+
+    shutdown(sock, SHUT_WR);
+    pthread_join(recv_thread, NULL);
+}
+
 int lmp_send(int fd, uint8_t type, const char *payload, uint32_t len)
 {
     lmp_header_t hdr;
@@ -437,14 +515,14 @@ int lmp_recv(int fd, uint8_t *type_out, char *buf, uint32_t bufsize, uint32_t *l
 
     /* Checking valid header */
     if (hdr.magic[0] != LMP_MAGIC_0 || hdr.magic[1] != LMP_MAGIC_1 || header_bytes < sizeof hdr)
-        return -1;
+        return -3;
 
     plen = ntohl(hdr.payload_len);
     if (plen >= bufsize)
-        return -1;
+        return -4;
 
     if (plen > 0 && read_all(fd, buf, plen) <= 0)
-        return -1;
+        return -5;
     buf[plen] = '\0';
 
     *type_out = hdr.type;

--- a/lmp.c
+++ b/lmp.c
@@ -162,13 +162,13 @@ static ssize_t read_all(int fd, void *buf, size_t n)
     return (ssize_t)total;
 }
 
-static void print_prompt(LMPContext *ctx)
+void print_prompt(LMPContext *ctx)
 {
     printf("\r\033[K[%s]: ", ctx->my_nick);
     fflush(stdout);
 }
 
-static void strip_newline(char *s)
+void strip_newline(char *s)
 {
     size_t len = strlen(s);
     if (len > 0 && s[len - 1] == '\n')
@@ -336,10 +336,7 @@ void chat(int sock, const char *role)
     peer_ip[sizeof(peer_ip) - 1] = '\0';
 
     init_commands(); /* Initialize all commands */
-    if (strcmp(role, "user") == 0)
-        chat_loop_user(sock, peer_ip, "");
-    else
-        chat_loop(sock, peer_ip, "");
+    chat_loop(sock, peer_ip, "");
 }
 
 /* Actual chat loop implementation */
@@ -385,75 +382,6 @@ void chat_loop(int sock, const char *peer_ip, const char *history_path)
     {
         /* wait for peer UID before allowing chat */
     }
-
-    while (1)
-    {
-        print_prompt(&ctx);
-        if (!fgets(line, sizeof(line), stdin))
-            break;
-        strip_newline(line);
-
-        if (line[0] == '/')
-        {
-            switch (dispatch_send(line + 1, &ctx))
-            {
-            case COMMAND_SUCCESS:
-                break;
-            case COMMAND_ERROR:
-                printf("Error executing '%s'\n", line);
-                break;
-            case COMMAND_UNRECOGNIZED:
-                printf("Unrecognized command '%s'\n", line);
-                break;
-            }
-        }
-        else
-        {
-            if (lmp_send(ctx.sock, LMP_MSG, line, (uint32_t)strlen(line)) == 0)
-                lmp_history_append(&ctx, ctx.my_nick, line);
-        }
-    }
-
-    shutdown(sock, SHUT_WR);
-    pthread_join(recv_thread, NULL);
-}
-
-void chat_loop_user(int sock, const char *server_ip, const char *history_path)
-{
-    pthread_t recv_thread;
-    char line[1024];
-    LMPContext ctx;
-    FILE *fp;
-    ctx.sock = sock;
-
-    strncpy(ctx.my_nick, "You", sizeof(ctx.my_nick) - 1);
-    strncpy(ctx.peer_nick, "Peer", sizeof(ctx.peer_nick) - 1);
-    ctx.my_nick[sizeof(ctx.my_nick) - 1] = '\0';
-    ctx.peer_nick[sizeof(ctx.peer_nick) - 1] = '\0';
-
-    /* Load saved nickname if it exists */
-    fp = open_file_in_user_directory("nick.txt", "r");
-    if (fp != NULL)
-    {
-        fscanf(fp, "%63s", ctx.my_nick);
-        fclose(fp);
-    }
-
-    strncpy(ctx.peer_ip, server_ip ? server_ip : "unknown_peer", sizeof(ctx.peer_ip) - 1);
-    ctx.peer_ip[sizeof(ctx.peer_ip) - 1] = '\0';
-
-    strncpy(ctx.history_path, history_path ? history_path : "", sizeof(ctx.history_path) - 1);
-    ctx.history_path[sizeof(ctx.history_path) - 1] = '\0';
-
-    ctx.peer_uid[0] = '\0';
-    ctx.history_loaded = 0;
-
-    strncpy(ctx.my_uid, get_uid(), sizeof(ctx.my_uid) - 1);
-    ctx.my_uid[sizeof(ctx.my_uid) - 1] = '\0';
-
-    pthread_create(&recv_thread, NULL, receiver, &ctx);
-
-    /* send GroupMember information here */
 
     while (1)
     {

--- a/lmp.c
+++ b/lmp.c
@@ -137,7 +137,7 @@ CommandResult dispatch_recv(uint8_t code, const char *buf, uint32_t len, LMPCont
     return COMMAND_UNRECOGNIZED;
 }
 
-static ssize_t read_all(int fd, void *buf, size_t n)
+ssize_t read_all(int fd, void *buf, size_t n)
 {
     size_t total = 0;
     char *p = (char *)buf;

--- a/lmp.h
+++ b/lmp.h
@@ -49,6 +49,7 @@ int lmp_recv(int fd, uint8_t *type_out, char *buf, uint32_t bufsize, uint32_t *l
 void chat(int sock, const char *role);
 
 void chat_loop(int sock, const char *peer_ip, const char *history_path);
+void chat_loop_user(int sock, const char *server_ip, const char *history_path);
 
 int get_peer_ip(int sockfd, char *ip_str, size_t ip_str_len);
 void connection_handler(int sock);

--- a/lmp.h
+++ b/lmp.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "group.h"
 
 #define LMP_MAGIC_0 0x4C
 #define LMP_MAGIC_1 0x4D
@@ -27,8 +28,8 @@ typedef enum
 typedef struct
 {
     int sock;
-    char peer_nick[64];
-    char my_nick[64];
+    char peer_nick[NICKNAME_MAX_LEN];
+    char my_nick[NICKNAME_MAX_LEN];
     char peer_ip[64];
     char my_uid[9];
     char peer_uid[9];
@@ -43,6 +44,9 @@ typedef CommandResult (*RecvHandler)(uint8_t code, const char *buf, uint32_t len
 void register_command(uint8_t code, const char *name, SendHandler send, RecvHandler recv);
 CommandResult dispatch_send(const char *line, LMPContext *ctx);
 CommandResult dispatch_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx);
+
+void print_prompt(LMPContext *ctx);
+void strip_newline(char *s);
 
 int lmp_send(int fd, uint8_t type, const char *payload, uint32_t len);
 int lmp_recv(int fd, uint8_t *type_out, char *buf, uint32_t bufsize, uint32_t *len_out);

--- a/lmp.h
+++ b/lmp.h
@@ -45,6 +45,7 @@ void register_command(uint8_t code, const char *name, SendHandler send, RecvHand
 CommandResult dispatch_send(const char *line, LMPContext *ctx);
 CommandResult dispatch_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx);
 
+ssize_t read_all(int fd, void *buf, size_t n);
 void print_prompt(LMPContext *ctx);
 void strip_newline(char *s);
 

--- a/test/test_group_client.c
+++ b/test/test_group_client.c
@@ -7,6 +7,7 @@
 #include "group.h"
 #include "group_comms.h"
 #include "group_user_comms.h"
+#include "lmp.h"
 
 /*
 Running Command:
@@ -53,8 +54,10 @@ int main()
         if ((tcp_socket = user_TCP_to_group_server(&server_addr)) > 0)
         {
             /* Receive from server */
+            /*
             char buffer[1024];
             int bytes_received;
+            */
             printf("\n--- Connected to Server via TCP ---\n");
 
             /* Send User's information, GroupMember */
@@ -65,20 +68,8 @@ int main()
                 return 1;
             }
 
-            while ((bytes_received = recv(tcp_socket, buffer, sizeof(buffer) - 1, 0)) > 0)
-            {
-                buffer[bytes_received] = '\0';
-                printf("%s\n", buffer);
-            }
+            chat(tcp_socket, "user");
 
-            if (bytes_received == 0)
-            {
-                printf("Connection closed by peer.\n");
-            }
-            else if (bytes_received == -1)
-            {
-                perror("recv failed");
-            }
             printf("\n--- Closing TCP Connection ---\n");
             close(tcp_socket);
         }

--- a/test/test_group_client.c
+++ b/test/test_group_client.c
@@ -68,7 +68,7 @@ int main()
                 return 1;
             }
 
-            chat(tcp_socket, "user");
+            group_chat(tcp_socket, "user");
 
             printf("\n--- Closing TCP Connection ---\n");
             close(tcp_socket);


### PR DESCRIPTION
Implement message sending between users in a group, through the server.

New LMP commands for group are made in `group_commands.c`. MSB should be 1 for Group commands (anything above 0x80).

LMP reserved bit has been used to send the sender's identity in the header. The index of the sender's `GroupMember` object in the `GroupMember` array in `Group` is sent in the reserved bit.

LMPContext (`peer_name` and `peer_uid`) is amended in every loop in `receiver`, so that `dispatch_recv` works as before (P2P connection). 

There are now two global `Group` objects -- `current_group` for server and `user_group` for user.

Every time a new connection is made, the `current_group` object is sent to all users, updating their `user_group` objects.