### PR TITLE
Refractor welcome message and add /gi to print group info once it has been updated

### DIFF
--- a/commands_registry.h
+++ b/commands_registry.h
@@ -11,7 +11,8 @@ typedef enum
     LMP_MEOW = 0x10,
     LMP_ERROR = 0xFF,
     LMP_UID = 0x04,
-    LMP_GRP_OBJ = 0x80
+    LMP_GRP_OBJ = 0x80,
+    LMP_GRP_INFO = 0x81
 } LMPCode;
 
 void init_commands(void);

--- a/group_commands.c
+++ b/group_commands.c
@@ -3,9 +3,11 @@
 #include "lmp.h"
 #include "group.h"
 #include "commands_registry.h"
+#include "group_user.h"
 
 extern Group current_group;
 extern Group user_group;
+int user_group_is_initialized = 0;
 
 /* GRP */
 CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx)
@@ -20,7 +22,12 @@ CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx)
 static CommandResult grp_obj_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx)
 {
     user_group = *(Group *)buf;
-    printf("[Server]: New group saved. Members: %d\n", user_group.member_count);
+    if (user_group_is_initialized == 0)
+    {
+        user_group_is_initialized = 1;
+        print_welcome_message(user_group);
+    }
+    printf("[Server]: Group information has been updated\n");
     return COMMAND_SUCCESS;
 }
 

--- a/group_commands.c
+++ b/group_commands.c
@@ -27,11 +27,25 @@ static CommandResult grp_obj_recv(uint8_t code, const char *buf, uint32_t len, L
         user_group_is_initialized = 1;
         print_welcome_message(user_group);
     }
-    printf("[Server]: Group information has been updated\n");
+    else
+    {
+        printf("[System]: Group information has been updated, type /gi to see the updated group information\n");
+    }
+    return COMMAND_SUCCESS;
+}
+
+/*
+Print group information
+Command: /gi
+*/
+static CommandResult grp_info_send(uint8_t code, const char *args, LMPContext *ctx)
+{
+    print_group_info(user_group);
     return COMMAND_SUCCESS;
 }
 
 void group_commands_init(void)
 {
     register_command(LMP_GRP_OBJ, "grpobj", grp_obj_send, grp_obj_recv);
+    register_command(LMP_GRP_INFO, "gi", grp_info_send, NULL);
 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -19,34 +19,6 @@ GroupConnection group_connections[MAX_GROUP_CONNECTIONS];
 Group current_group;
 int connection_count = 0;
 
-static void append_text(char *dest, size_t dest_size, const char *src)
-{
-    size_t dest_len;
-    size_t src_len;
-    size_t copy_len;
-
-    if (dest_size == 0)
-    {
-        return;
-    }
-
-    dest_len = strlen(dest);
-    if (dest_len >= dest_size - 1)
-    {
-        return;
-    }
-
-    src_len = strlen(src);
-    copy_len = dest_size - dest_len - 1;
-    if (src_len < copy_len)
-    {
-        copy_len = src_len;
-    }
-
-    memcpy(dest + dest_len, src, copy_len);
-    dest[dest_len + copy_len] = '\0';
-}
-
 /*
 For Server, create group_server_UDP_reply as a seperate thread
 */
@@ -208,54 +180,6 @@ void add_to_global_connections(GroupMember member, int user_sock)
     return;
 }
 
-/*
- * Send welcome message to newest connection
- * Returns success (0) or fail (1)
- */
-int send_welcome_message(GroupMember member, int user_sock)
-{
-    int i;
-    char response[1024];
-    const char *nickname;
-    const char *group_name;
-    LMPContext ctx;
-    ctx.sock = user_sock;
-    nickname = (member.nickname[0] != '\0') ? member.nickname : "Unknown";
-    group_name = (current_group.info.group_name[0] != '\0') ? current_group.info.group_name : "Unknown Group";
-
-    response[0] = '\0';
-    append_text(response, sizeof(response), "Hello ");
-    append_text(response, sizeof(response), nickname);
-    append_text(response, sizeof(response), ",\n");
-    append_text(response, sizeof(response), "Welcome to group ");
-    append_text(response, sizeof(response), group_name);
-    append_text(response, sizeof(response), "\n");
-    append_text(response, sizeof(response), "Current members:\n");
-
-    for (i = 0; i < connection_count; i++)
-    {
-        const char *list_nickname;
-        const char *list_uid;
-
-        list_nickname = (group_connections[i].member.nickname[0] != '\0') ? group_connections[i].member.nickname : "Unknown";
-        list_uid = (group_connections[i].member.uid[0] != '\0') ? group_connections[i].member.uid : "Unknown";
-
-        append_text(response, sizeof(response), "- ");
-        append_text(response, sizeof(response), list_nickname);
-        append_text(response, sizeof(response), " (UID: ");
-        append_text(response, sizeof(response), list_uid);
-        append_text(response, sizeof(response), ")\n");
-    }
-
-    if ((lmp_send(user_sock, LMP_MSG, response, (uint32_t)strlen(response))) < 0)
-        return -1;
-
-    printf("Current number of members: %d\n", current_group.member_count);
-    if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
-        return -1;
-    return 0;
-}
-
 int send_new_group_to_users(int listener, int sender_fd,
                             int *fd_count, struct pollfd **pfds)
 {
@@ -266,8 +190,8 @@ int send_new_group_to_users(int listener, int sender_fd,
     {
         int dest_fd = (*pfds)[i].fd;
         ctx.sock = dest_fd;
-        /* Except the listener and ourselves */
-        if (dest_fd != listener && dest_fd != sender_fd)
+        /* Except the listener */
+        if (dest_fd != listener)
         {
             if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
             {
@@ -321,13 +245,6 @@ void handle_new_connection(int listener, int *fd_count,
 
     printf("[Group TCP] Accepted connection from %s\n",
            inet_ntoa(remoteaddr.sin_addr));
-
-    if (send_welcome_message(member, newfd) != 0)
-    {
-        perror("send_welcome_message");
-        close(newfd);
-        return;
-    }
 
     if (send_new_group_to_users(listener, newfd, fd_count, pfds) != 0)
     {

--- a/group_user.c
+++ b/group_user.c
@@ -1,0 +1,40 @@
+/*
+group_user.c
+Dedicated for functions which only user (client) side needs, such as printing welcome message using group information sent by server.
+*/
+#include <stdio.h>
+#include <string.h>
+#include "group.h"
+#include "group_user.h"
+
+/* used in /gi (group info) and welcome message */
+void print_group_info(Group group)
+{
+    /*
+    [<group name>]
+    Current members (<number of members>):
+     -<nickname> (UID: <UID>)
+     */
+    int i;
+    const char *group_name = (group.info.group_name[0] != '\0') ? group.info.group_name : "Unknown Group";
+    printf("[%s]\nCurrent members (%d):\n", group_name, group.member_count);
+    for (i = 0; i < group.member_count; i++)
+    {
+        const char *nickname = (group.members[i].nickname[0] != '\0') ? group.members[i].nickname : "Unknown";
+        const char *uid = (group.members[i].uid[0] != '\0') ? group.members[i].uid : "Unknown";
+        printf("- %s (UID: %s)\n", nickname, uid);
+    }
+}
+
+/* Print welcome message */
+void print_welcome_message(Group group)
+{
+    /*
+    Message Format:
+    Welcome to group [<group name>]
+    Current members (<number of members>):
+    - <nickname> (UID: <UID>)
+    */
+    printf("Welcome to group ");
+    print_group_info(group);
+}

--- a/group_user.h
+++ b/group_user.h
@@ -1,0 +1,9 @@
+/* group_user.h */
+#ifndef GROUP_USER_H
+#define GROUP_USER_H
+
+#include "group.h"
+
+void print_welcome_message(Group group);
+
+#endif /* GROUP_USER_H */

--- a/group_user.h
+++ b/group_user.h
@@ -5,5 +5,6 @@
 #include "group.h"
 
 void print_welcome_message(Group group);
+void print_group_info(Group group);
 
 #endif /* GROUP_USER_H */


### PR DESCRIPTION
As described, welcome message has been tasked to client rather than server to send, decreasing the work needed on the server. Simplifying it alot.
Also the added `user_group_is_initialized` help keep track if it's the first time the user is receiving the group information if it's it will print welcome message.
Added `/gi` command for user to print group information