### PR TITLE
51 phase 3 feat set nickname in group

### DIFF
--- a/base_commands.c
+++ b/base_commands.c
@@ -2,6 +2,9 @@
 #include <string.h>
 #include "lmp.h"
 #include "commands_registry.h"
+#include "group_user.h"
+
+int user_group_MODE;
 
 /* MSG */
 static CommandResult msg_send(uint8_t code, const char *args, LMPContext *ctx)
@@ -22,9 +25,12 @@ static CommandResult msg_recv(uint8_t code, const char *buf, uint32_t len, LMPCo
 /* NICK */
 static CommandResult nick_send(uint8_t code, const char *args, LMPContext *ctx)
 {
-    strncpy(ctx->my_nick, args, sizeof(ctx->my_nick) - 1);
-    ctx->my_nick[sizeof(ctx->my_nick) - 1] = '\0';
-    lmp_save_nick(ctx->my_nick); /* Save nickname to disk so it persists across sessions */
+    if (user_group_MODE == 0) /* One to one connection */
+    {
+        strncpy(ctx->my_nick, args, sizeof(ctx->my_nick) - 1);
+        ctx->my_nick[sizeof(ctx->my_nick) - 1] = '\0';
+        lmp_save_nick(ctx->my_nick); /* Save nickname to disk so it persists across sessions */
+    }
     if (lmp_send(ctx->sock, code, args, (uint32_t)strlen(args)) < 0)
         return COMMAND_ERROR;
     return COMMAND_SUCCESS;

--- a/commands_registry.h
+++ b/commands_registry.h
@@ -11,9 +11,11 @@ typedef enum
     LMP_MEOW = 0x10,
     LMP_ERROR = 0xFF,
     LMP_UID = 0x04,
-    LMP_GRP_OBJ = 0x80,        /* Server > User */
-    LMP_GRP_INFO = 0x11,       /* User only */
-    LMP_GRP_INIT_MEMBER = 0x12 /* User > Server */
+    LMP_GRP_OBJ = 0x80,         /* Server > User */
+    LMP_GRP_INFO = 0x11,        /* User only */
+    LMP_GRP_INIT_MEMBER = 0x12, /* User > Server */
+    LMP_GRP_LOAD_MSG = 0x13,    /* User > Server > Client */
+    LMP_GRP_LOADING_MSG = 0x14  /* Server > User */
 } LMPCode;
 
 void init_commands(void);

--- a/commands_registry.h
+++ b/commands_registry.h
@@ -11,8 +11,9 @@ typedef enum
     LMP_MEOW = 0x10,
     LMP_ERROR = 0xFF,
     LMP_UID = 0x04,
-    LMP_GRP_OBJ = 0x80,
-    LMP_GRP_INFO = 0x81
+    LMP_GRP_OBJ = 0x80,        /* Server > User */
+    LMP_GRP_INFO = 0x11,       /* User only */
+    LMP_GRP_INIT_MEMBER = 0x12 /* User > Server */
 } LMPCode;
 
 void init_commands(void);

--- a/directory_manager.c
+++ b/directory_manager.c
@@ -107,3 +107,29 @@ FILE *open_file_in_user_directory(const char *filename, const char *mode)
     file = fopen(filepath, mode);
     return file;
 }
+
+void init_group_server_directory(const char *uid, char *group_dir, size_t group_dir_size)
+{
+    char root_directory[512];
+    size_t root_len;
+    size_t uid_len;
+    size_t prefix_len;
+
+    get_root_directory(root_directory, sizeof(root_directory));
+
+    root_len = strlen(root_directory);
+    uid_len = strlen(uid);
+    prefix_len = 8; /* "/server/" */
+
+    if (root_len + prefix_len + uid_len + 1 > group_dir_size)
+    {
+        fprintf(stderr, "group directory path too long\n");
+        exit(EXIT_FAILURE);
+    }
+
+    memcpy(group_dir, root_directory, root_len);
+    memcpy(group_dir + root_len, "/server/", prefix_len);
+    memcpy(group_dir + root_len + prefix_len, uid, uid_len + 1);
+
+    make_directory(group_dir);
+}

--- a/directory_manager.h
+++ b/directory_manager.h
@@ -9,4 +9,6 @@ void set_program_username(const char *pusername);
 FILE *open_file_in_user_directory(const char *filename, const char *mode);
 void init_user_directory(void);
 
+void init_group_server_directory(const char *uid, char *group_dir, size_t group_dir_size);
+
 #endif /* DIRECTORY_MANAGER_H */

--- a/group.h
+++ b/group.h
@@ -28,10 +28,10 @@ typedef struct Group
 
 extern Group current_group;
 
-typedef struct MessageFormat
+typedef struct HistoryFormat
 {
     char uid[UID_LENGTH];
     char message[1024 - UID_LENGTH];
-} MessageFormat; /* Ensure MessageFormat is size of 1024 */
+} HistoryFormat; /* Ensure HistoryFormat is size of 1024 */
 
 #endif /* GROUP_H */

--- a/group.h
+++ b/group.h
@@ -28,4 +28,10 @@ typedef struct Group
 
 extern Group current_group;
 
+typedef struct MessageFormat
+{
+    char uid[UID_LENGTH];
+    char message[1024 - UID_LENGTH];
+} MessageFormat; /* Ensure MessageFormat is size of 1024 */
+
 #endif /* GROUP_H */

--- a/group_commands.c
+++ b/group_commands.c
@@ -4,9 +4,11 @@
 #include "group.h"
 #include "commands_registry.h"
 #include "group_user.h"
+#include "group_commands.h"
 
 extern Group current_group;
 extern Group user_group;
+GroupMember user_member_info;
 int user_group_is_initialized;
 
 /* GRP */
@@ -41,6 +43,15 @@ Command: /gi
 static CommandResult grp_info_send(uint8_t code, const char *args, LMPContext *ctx)
 {
     print_group_info(user_group);
+
+    return COMMAND_SUCCESS;
+}
+
+/* [LMP_GRP_INIT_MEMBER] Send member information to the group server */
+CommandResult user_grp_init_send(const int sock)
+{
+    if (lmp_send(sock, LMP_GRP_INIT_MEMBER, (char *)&user_member_info, sizeof(user_member_info)) < 0)
+        return COMMAND_ERROR;
     return COMMAND_SUCCESS;
 }
 
@@ -48,4 +59,5 @@ void group_commands_init(void)
 {
     register_command(LMP_GRP_OBJ, "grpobj", grp_obj_send, grp_obj_recv);
     register_command(LMP_GRP_INFO, "gi", grp_info_send, NULL);
+    register_command(LMP_GRP_INIT_MEMBER, "initmember", NULL, NULL);
 }

--- a/group_commands.c
+++ b/group_commands.c
@@ -55,9 +55,85 @@ CommandResult user_grp_init_send(const int sock)
     return COMMAND_SUCCESS;
 }
 
+/* Initiate load history message from server */
+/* Usage: /load */
+static CommandResult user_grp_load_msg_send(uint8_t code, const char *args, LMPContext *ctx)
+{
+    if (loading_message_state == STATE_REQUESTING_LOAD)
+    {
+        printf("[System]: Already requesting load, please wait...\n");
+        return COMMAND_SUCCESS;
+    }
+    if (loading_message_state == STATE_LOADING)
+    {
+        printf("[System]: Loading, please wait...\n");
+        return COMMAND_SUCCESS;
+    }
+    printf("[System]: Loading History...\n");
+    loading_message_state = STATE_REQUESTING_LOAD;
+    if (lmp_send(ctx->sock, LMP_GRP_LOAD_MSG, NULL, 0) < 0)
+        return COMMAND_ERROR;
+    return COMMAND_SUCCESS;
+}
+
+static CommandResult user_grp_load_msg_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx)
+{
+    if (loading_message_state == STATE_REQUESTING_LOAD || loading_message_state == STATE_LOADING)
+    {
+        loading_message_state = STATE_IDLE;
+    }
+    return COMMAND_SUCCESS;
+}
+
+static CommandResult user_grp_loading_msg_recv(uint8_t code, const char *buf, uint32_t len, LMPContext *ctx)
+{
+    HistoryFormat *history;
+    int i;
+    const char *nickname;
+    char uid[UID_LENGTH + 1];
+
+    if (loading_message_state == STATE_IDLE)
+    {
+        printf("[System]: Received unexpected loading message, ignoring...\n");
+        return COMMAND_SUCCESS;
+    }
+
+    loading_message_state = STATE_LOADING;
+
+    history = (HistoryFormat *)buf;
+    nickname = "Unknown";
+
+    /* Copy first UID_LENGTH characters from history->uid and add null terminator */
+    strncpy(uid, history->uid, UID_LENGTH);
+    uid[UID_LENGTH] = '\0';
+
+    /* if user_member_info uid is the same as the history uid */
+    if (strcmp(user_member_info.uid, uid) == 0)
+    {
+        nickname = "You";
+    }
+    else
+    {
+        for (i = 0; i < user_group.member_count; i++)
+        {
+            if (strcmp(user_group.members[i].uid, uid) == 0)
+            {
+                nickname = user_group.members[i].nickname;
+                break;
+            }
+        }
+    }
+
+    printf("[%s]: %s", nickname, history->message);
+
+    return COMMAND_SUCCESS;
+}
+
 void group_commands_init(void)
 {
     register_command(LMP_GRP_OBJ, "grpobj", grp_obj_send, grp_obj_recv);
     register_command(LMP_GRP_INFO, "gi", grp_info_send, NULL);
     register_command(LMP_GRP_INIT_MEMBER, "initmember", NULL, NULL);
+    register_command(LMP_GRP_LOAD_MSG, "load", user_grp_load_msg_send, user_grp_load_msg_recv);
+    register_command(LMP_GRP_LOADING_MSG, "grploadingmsg", NULL, user_grp_loading_msg_recv);
 }

--- a/group_commands.c
+++ b/group_commands.c
@@ -7,7 +7,7 @@
 
 extern Group current_group;
 extern Group user_group;
-int user_group_is_initialized = 0;
+int user_group_is_initialized;
 
 /* GRP */
 CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx)

--- a/group_commands.h
+++ b/group_commands.h
@@ -5,6 +5,7 @@
 
 CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx);
 CommandResult user_grp_init_send(const int sock);
+CommandResult server_grp_loading_msg_send(int sock, HistoryFormat *history);
 
 void group_commands_init(void);
 

--- a/group_commands.h
+++ b/group_commands.h
@@ -4,6 +4,7 @@
 #include "lmp.h"
 
 CommandResult grp_obj_send(uint8_t code, const char *args, LMPContext *ctx);
+CommandResult user_grp_init_send(const int sock);
 
 void group_commands_init(void);
 

--- a/group_server.c
+++ b/group_server.c
@@ -7,31 +7,14 @@
 
 extern Group current_group;
 char group_dir[512];
+char history_file_path[512];
 
 int save_message_to_history(const char *uid, const char *message)
 {
-    char history_file_path[512];
     FILE *history_file;
-    size_t group_dir_len;
-    size_t history_file_len;
-    size_t total_len;
 
-    MessageFormat message_format;
-    memset(&message_format, 0, sizeof(MessageFormat));
-
-    group_dir_len = strlen(group_dir);
-    history_file_len = strlen(GROUP_HISTORY_FILE);
-    total_len = group_dir_len + history_file_len;
-
-    if (total_len >= sizeof(history_file_path))
-    {
-        fprintf(stderr, "History file path too long\n");
-        return -1;
-    }
-
-    memcpy(history_file_path, group_dir, group_dir_len);
-    memcpy(history_file_path + group_dir_len, GROUP_HISTORY_FILE, history_file_len);
-    history_file_path[total_len] = '\0';
+    HistoryFormat message_format;
+    memset(&message_format, 0, sizeof(HistoryFormat));
 
     history_file = fopen(history_file_path, "a");
     if (!history_file)
@@ -66,10 +49,34 @@ int save_message_to_history(const char *uid, const char *message)
 
 void init_group_server(const char *group_UID)
 {
+    size_t group_dir_len;
+    size_t history_file_len;
+    size_t total_len;
+
     init_group_server_directory(group_UID, group_dir, sizeof(group_dir));
     /* add "/" to the end of group_dir */
     if (group_dir[strlen(group_dir) - 1] != '/')
     {
         strcat(group_dir, "/");
     }
+
+    group_dir_len = strlen(group_dir);
+    history_file_len = strlen(GROUP_HISTORY_FILE);
+    total_len = group_dir_len + history_file_len;
+
+    if (total_len >= sizeof(history_file_path))
+    {
+        fprintf(stderr, "History file path too long\n");
+        history_file_path[0] = '\0';
+        return;
+    }
+
+    memcpy(history_file_path, group_dir, group_dir_len);
+    memcpy(history_file_path + group_dir_len, GROUP_HISTORY_FILE, history_file_len);
+    history_file_path[total_len] = '\0';
+}
+
+char *get_history_file_path()
+{
+    return history_file_path;
 }

--- a/group_server.c
+++ b/group_server.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <string.h>
+#include "group.h"
+#include "directory_manager.h"
+#include "group_server.h"
+#include "uid.h"
+
+extern Group current_group;
+char group_dir[512];
+
+int save_message_to_history(const char *uid, const char *message)
+{
+    char history_file_path[512];
+    FILE *history_file;
+    size_t group_dir_len;
+    size_t history_file_len;
+    size_t total_len;
+
+    MessageFormat message_format;
+    memset(&message_format, 0, sizeof(MessageFormat));
+
+    group_dir_len = strlen(group_dir);
+    history_file_len = strlen(GROUP_HISTORY_FILE);
+    total_len = group_dir_len + history_file_len;
+
+    if (total_len >= sizeof(history_file_path))
+    {
+        fprintf(stderr, "History file path too long\n");
+        return -1;
+    }
+
+    memcpy(history_file_path, group_dir, group_dir_len);
+    memcpy(history_file_path + group_dir_len, GROUP_HISTORY_FILE, history_file_len);
+    history_file_path[total_len] = '\0';
+
+    history_file = fopen(history_file_path, "a");
+    if (!history_file)
+    {
+        perror("Error opening history file");
+        return -1;
+    }
+
+    /* Check the uid is length of UID_LENGTH */
+    if (strlen(uid) != UID_LENGTH)
+    {
+        fprintf(stderr, "Invalid UID length\n");
+        return -1;
+    }
+
+    strncpy(message_format.uid, uid, UID_LENGTH);
+
+    /* Check the message length less than 1024 - UID_LENGTH */
+
+    if (strlen(message) >= sizeof(message_format.message))
+    {
+        fprintf(stderr, "Message too long\n");
+        return -1;
+    }
+
+    strncpy(message_format.message, message, sizeof(message_format.message) - 1);
+
+    fprintf(history_file, "%s\n", (char *)&message_format);
+    fclose(history_file);
+    return 0;
+}
+
+void init_group_server(const char *group_UID)
+{
+    init_group_server_directory(group_UID, group_dir, sizeof(group_dir));
+    /* add "/" to the end of group_dir */
+    if (group_dir[strlen(group_dir) - 1] != '/')
+    {
+        strcat(group_dir, "/");
+    }
+}

--- a/group_server.h
+++ b/group_server.h
@@ -5,5 +5,6 @@
 
 int save_message_to_history(const char *uid, const char *message);
 void init_group_server(const char *group_UID);
+char *get_history_file_path();
 
 #endif /* GROUP_SERVER_H */

--- a/group_server.h
+++ b/group_server.h
@@ -1,0 +1,9 @@
+/* group_server.h */
+#ifndef GROUP_SERVER_H
+#define GROUP_SERVER_H
+#define GROUP_HISTORY_FILE "history.txt"
+
+int save_message_to_history(const char *uid, const char *message);
+void init_group_server(const char *group_UID);
+
+#endif /* GROUP_SERVER_H */

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -15,9 +15,7 @@
 #include "lmp.h"
 #include "commands_registry.h"
 
-GroupConnection group_connections[MAX_GROUP_CONNECTIONS];
 Group current_group;
-int connection_count = 0;
 
 /*
 For Server, create group_server_UDP_reply as a seperate thread
@@ -169,23 +167,11 @@ void del_from_pfds(struct pollfd pfds[], int i, int *fd_count)
     (*fd_count)--;
 }
 
-/* Add member to global connections */
-void add_to_global_connections(GroupMember member, int user_sock)
-{
-    group_connections[connection_count].tcp_socket = user_sock;
-    group_connections[connection_count].member = member;
-    connection_count++;
-    current_group.members[current_group.member_count] = member;
-    current_group.member_count++;
-    return;
-}
-
 int send_new_group_to_users(int listener, int sender_fd,
                             int *fd_count, struct pollfd **pfds)
 {
     int i;
     LMPContext ctx;
-
     for (i = 0; i < *fd_count; i++)
     {
         int dest_fd = (*pfds)[i].fd;
@@ -206,17 +192,11 @@ int send_new_group_to_users(int listener, int sender_fd,
 /*
  * Handle incoming connections.
  */
-void handle_new_connection(int listener, int *fd_count,
-                           int *fd_size, struct pollfd **pfds)
+void handle_new_connection(int listener, int *fd_count, int *fd_size, struct pollfd **pfds)
 {
     struct sockaddr_in remoteaddr; /* Client address */
-    socklen_t addrlen;
-    int newfd;                /* Newly accept()ed socket descriptor */
-    GroupMember member = {0}; /* Initialize member with zeros */
-
-    addrlen = sizeof remoteaddr;
-    newfd = accept(listener, (struct sockaddr *)&remoteaddr,
-                   &addrlen);
+    socklen_t addrlen = sizeof(remoteaddr);
+    int newfd = accept(listener, (struct sockaddr *)&remoteaddr, &addrlen);
 
     if (newfd == -1)
     {
@@ -224,34 +204,9 @@ void handle_new_connection(int listener, int *fd_count,
         return;
     }
 
-    /* Continue if accept is successful */
-
-    if (connection_count >= MAX_GROUP_CONNECTIONS)
-    {
-        fprintf(stderr, "Maximum connection limit reached. Cannot add more connections.\n");
-        close(newfd);
-        return;
-    }
-
-    /* Continue if both accept is successful and
-        connection limit has not been reached */
-
     add_to_pfds(pfds, newfd, fd_count, fd_size);
-
-    /* Receive member info (UID and nickname) */
-    recv(newfd, (void *)&member, sizeof(member), 0);
-
-    add_to_global_connections(member, newfd);
-
-    printf("[Group TCP] Accepted connection from %s\n",
-           inet_ntoa(remoteaddr.sin_addr));
-
-    if (send_new_group_to_users(listener, newfd, fd_count, pfds) != 0)
-    {
-        perror("send_new_group_to_users");
-        close(newfd);
-        return;
-    }
+    printf("[Group TCP] Accepted connection from %s\n", inet_ntoa(remoteaddr.sin_addr));
+    printf("[Group TCP] Awaiting group member information...\n");
 }
 
 int group_lmp_send(int fd, uint8_t type, const char *payload, uint32_t len, int sender)
@@ -273,8 +228,7 @@ int group_lmp_send(int fd, uint8_t type, const char *payload, uint32_t len, int 
 /*
  * Handle regular client data or client hangups.
  */
-void handle_client_data(int listener, int *fd_count,
-                        struct pollfd *pfds, int *pfd_i)
+void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *pfd_i)
 {
     uint8_t type;
     char buf[4096];
@@ -284,8 +238,8 @@ void handle_client_data(int listener, int *fd_count,
     int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
 
     int j;
-    LMPContext ctx;
     int sender_connection_index;
+    GroupMember new_member;
 
     if (recv_status < 0)
     { /* Got error or connection closed by client */
@@ -318,19 +272,20 @@ void handle_client_data(int listener, int *fd_count,
             strncpy(current_group.members[sender_connection_index].nickname, buf, NICKNAME_MAX_LEN - 1);
             current_group.members[sender_connection_index].nickname[NICKNAME_MAX_LEN - 1] = '\0'; /* Ensure null termination */
 
-            /* Send group object to all users */
-            for (j = 0; j < *fd_count; j++)
+            if (send_new_group_to_users(listener, sender_fd, fd_count, &pfds) != 0)
             {
-                int dest_fd = pfds[j].fd;
-                ctx.sock = dest_fd;
-                /* Except the listener */
-                if (dest_fd != listener)
-                {
-                    if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
-                    {
-                        perror("grp_obj_send");
-                    }
-                }
+                perror("send_new_group_to_users");
+            }
+            break;
+        case LMP_GRP_INIT_MEMBER: /* When user initializes their member information */
+            new_member = *(GroupMember *)buf;
+            printf("[Server] Received new member information: UID=%s, Nickname=%s\n", new_member.uid, new_member.nickname);
+            current_group.members[current_group.member_count] = new_member;
+            current_group.member_count++;
+
+            if (send_new_group_to_users(listener, sender_fd, fd_count, &pfds) != 0)
+            {
+                perror("send_new_group_to_users");
             }
             break;
         default:
@@ -356,8 +311,7 @@ void handle_client_data(int listener, int *fd_count,
 /*
  * Process all existing connections.
  */
-void process_connections(int listener, int *fd_count, int *fd_size,
-                         struct pollfd **pfds)
+void process_connections(int listener, int *fd_count, int *fd_size, struct pollfd **pfds)
 {
     int i;
     for (i = 0; i < *fd_count; i++)

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -164,12 +164,12 @@ void del_from_pfds(struct pollfd pfds[], int i, int *fd_count)
 {
     /* Copy the one from the end over this one */
     pfds[i] = pfds[*fd_count - 1];
-
+    current_group.members[i - 1] = current_group.members[*fd_count - 2]; /* Update group member info, -1 for listener offset */
+    current_group.member_count--;
     (*fd_count)--;
 }
 
-int send_new_group_to_users(int listener, int sender_fd,
-                            int *fd_count, struct pollfd **pfds)
+int send_new_group_to_users(int listener, int *fd_count, struct pollfd **pfds)
 {
     int i;
     LMPContext ctx;
@@ -261,6 +261,11 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
 
         del_from_pfds(pfds, *pfd_i, fd_count);
 
+        if (send_new_group_to_users(listener, fd_count, &pfds) != 0)
+        {
+            perror("send_new_group_to_users");
+        }
+
         /* reexamine the slot we just deleted */
         (*pfd_i)--;
     }
@@ -275,7 +280,7 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
             strncpy(current_group.members[sender_connection_index].nickname, buf, NICKNAME_MAX_LEN - 1);
             current_group.members[sender_connection_index].nickname[NICKNAME_MAX_LEN - 1] = '\0'; /* Ensure null termination */
 
-            if (send_new_group_to_users(listener, sender_fd, fd_count, &pfds) != 0)
+            if (send_new_group_to_users(listener, fd_count, &pfds) != 0)
             {
                 perror("send_new_group_to_users");
             }
@@ -286,7 +291,7 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
             current_group.members[current_group.member_count] = new_member;
             current_group.member_count++;
 
-            if (send_new_group_to_users(listener, sender_fd, fd_count, &pfds) != 0)
+            if (send_new_group_to_users(listener, fd_count, &pfds) != 0)
             {
                 perror("send_new_group_to_users");
             }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -11,6 +11,7 @@
 #include "group.h"
 #include "group_comms.h"
 #include "group_commands.h"
+#include "group_server.h"
 #include "group_server_comms.h"
 #include "lmp.h"
 #include "commands_registry.h"
@@ -288,6 +289,11 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
                 perror("send_new_group_to_users");
             }
             break;
+        case LMP_MSG: /* Save message to history.txt */
+            if (save_message_to_history(current_group.members[sender_connection_index].uid, buf) != 0)
+            {
+                perror("Failed to save message to history");
+            }
         default:
             for (j = 0; j < *fd_count; j++)
             {
@@ -295,8 +301,6 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
                 /* Except the listener and ourselves */
                 if (dest_fd != listener && dest_fd != sender_fd)
                 {
-                    /* Nick */
-                    /* type == /nick, update group, send group object */
                     if (group_lmp_send(dest_fd, type, buf, len, sender_connection_index) == -1)
                     {
                         perror("send");

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -276,14 +276,16 @@ int group_lmp_send(int fd, uint8_t type, const char *payload, uint32_t len, int 
 void handle_client_data(int listener, int *fd_count,
                         struct pollfd *pfds, int *pfd_i)
 {
-    int j;
     uint8_t type;
     char buf[4096];
     uint32_t len;
 
-    int sender_connection_index;
     int sender_fd = pfds[*pfd_i].fd;
     int recv_status = lmp_recv(pfds[*pfd_i].fd, &type, buf, sizeof buf, &len);
+
+    int j;
+    LMPContext ctx;
+    int sender_connection_index;
 
     if (recv_status < 0)
     { /* Got error or connection closed by client */
@@ -306,22 +308,47 @@ void handle_client_data(int listener, int *fd_count,
         (*pfd_i)--;
     }
     else
-    { /* We got some good data from a client */
-        printf("[Server] recv from fd %d: %.*s\n", sender_fd,
-               len, buf);
-        /* Send to everyone! */
+    {
+        printf("[Server] recv from fd %d: %.*s\n", sender_fd, len, buf);
         sender_connection_index = *pfd_i - 1; /* pollfd have one extra listener */
-        for (j = 0; j < *fd_count; j++)
+        switch (type)
         {
-            int dest_fd = pfds[j].fd;
-            /* Except the listener and ourselves */
-            if (dest_fd != listener && dest_fd != sender_fd)
+        case LMP_NICK: /* Check if type == /nick */
+            printf("[Server] Update username from %s to %s\n", current_group.members[sender_connection_index].nickname, buf);
+            strncpy(current_group.members[sender_connection_index].nickname, buf, NICKNAME_MAX_LEN - 1);
+            current_group.members[sender_connection_index].nickname[NICKNAME_MAX_LEN - 1] = '\0'; /* Ensure null termination */
+
+            /* Send group object to all users */
+            for (j = 0; j < *fd_count; j++)
             {
-                if (group_lmp_send(dest_fd, type, buf, len, sender_connection_index) == -1)
+                int dest_fd = pfds[j].fd;
+                ctx.sock = dest_fd;
+                /* Except the listener */
+                if (dest_fd != listener)
                 {
-                    perror("send");
+                    if ((grp_obj_send(LMP_GRP_OBJ, "", &ctx)) < 0)
+                    {
+                        perror("grp_obj_send");
+                    }
                 }
             }
+            break;
+        default:
+            for (j = 0; j < *fd_count; j++)
+            {
+                int dest_fd = pfds[j].fd;
+                /* Except the listener and ourselves */
+                if (dest_fd != listener && dest_fd != sender_fd)
+                {
+                    /* Nick */
+                    /* type == /nick, update group, send group object */
+                    if (group_lmp_send(dest_fd, type, buf, len, sender_connection_index) == -1)
+                    {
+                        perror("send");
+                    }
+                }
+            }
+            break;
         }
     }
 }

--- a/group_server_comms.c
+++ b/group_server_comms.c
@@ -242,6 +242,8 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
     int sender_connection_index;
     GroupMember new_member;
 
+    FILE *history_file;
+
     if (recv_status < 0)
     { /* Got error or connection closed by client */
         if (recv_status == -2)
@@ -288,6 +290,23 @@ void handle_client_data(int listener, int *fd_count, struct pollfd *pfds, int *p
             {
                 perror("send_new_group_to_users");
             }
+            break;
+        case LMP_GRP_LOAD_MSG: /* When user initiates load history message */
+            printf("[Server] Received load history request from user %s\n", current_group.members[sender_connection_index].nickname);
+
+            /* Using LMP_GRP_LOADING_MSG send each line in the history file */
+            history_file = fopen(get_history_file_path(), "r");
+            if (history_file)
+            {
+                char line[1024];
+                while (fgets(line, sizeof(line), history_file))
+                {
+                    lmp_send(sender_fd, LMP_GRP_LOADING_MSG, line, strlen(line));
+                }
+                fclose(history_file);
+            }
+
+            lmp_send(sender_fd, LMP_GRP_LOAD_MSG, "", 0); /* Trigger user FSM to STATE_IDLE */
             break;
         case LMP_MSG: /* Save message to history.txt */
             if (save_message_to_history(current_group.members[sender_connection_index].uid, buf) != 0)

--- a/group_server_comms.h
+++ b/group_server_comms.h
@@ -6,16 +6,6 @@
 
 #define MAX_GROUP_CONNECTIONS (MAX_GROUP_MEMBERS + 5) /* Allow some buffer for extra connections */
 
-/* Array of TCP connections to UID */
-typedef struct GroupConnection
-{
-    GroupMember member; /* Group member information (UID) */
-    int tcp_socket;     /* TCP socket file descriptor */
-} GroupConnection;
-
-extern GroupConnection group_connections[MAX_GROUP_CONNECTIONS];
-extern int connection_count; /* Number of active connections */
-
 pthread_t server_create_UDP_reply_thread();
 void group_server_UDP_reply(GroupInfo *group_info);
 int group_server_TCP_listen();

--- a/group_user.c
+++ b/group_user.c
@@ -7,6 +7,8 @@ Dedicated for functions which only user (client) side needs, such as printing we
 #include "group.h"
 #include "group_user.h"
 
+State_t loading_message_state = STATE_IDLE;
+
 /* used in /gi (group info) and welcome message */
 void print_group_info(Group group)
 {

--- a/group_user.h
+++ b/group_user.h
@@ -5,6 +5,7 @@
 
 extern int user_group_is_initialized;
 extern int user_group_MODE;
+extern GroupMember user_member_info;
 
 void print_welcome_message(Group group);
 void print_group_info(Group group);

--- a/group_user.h
+++ b/group_user.h
@@ -7,6 +7,15 @@ extern int user_group_is_initialized;
 extern int user_group_MODE;
 extern GroupMember user_member_info;
 
+typedef enum
+{
+    STATE_IDLE,
+    STATE_REQUESTING_LOAD,
+    STATE_LOADING
+} State_t;
+
+extern State_t loading_message_state;
+
 void print_welcome_message(Group group);
 void print_group_info(Group group);
 

--- a/group_user.h
+++ b/group_user.h
@@ -1,8 +1,10 @@
 /* group_user.h */
 #ifndef GROUP_USER_H
 #define GROUP_USER_H
-
 #include "group.h"
+
+extern int user_group_is_initialized;
+extern int user_group_MODE;
 
 void print_welcome_message(Group group);
 void print_group_info(Group group);

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -8,6 +8,7 @@
 #include <pthread.h>
 #include "uid.h"
 #include "group.h"
+#include "group_user.h"
 #include "group_comms.h"
 #include "group_user_comms.h"
 #include "lmp.h"
@@ -134,7 +135,8 @@ void group_chat(int sock, const char *role)
 
     peer_ip[sizeof(peer_ip) - 1] = '\0';
 
-    init_commands(); /* Initialize all commands */
+    init_commands();     /* Initialize all commands */
+    user_group_MODE = 1; /* Set mode to user_group */
     chat_loop_user(sock, peer_ip, "");
 }
 
@@ -203,33 +205,39 @@ void chat_loop_user(int sock, const char *server_ip, const char *history_path)
     pthread_t recv_thread;
     char line[1024];
     LMPContext ctx;
-    FILE *fp;
+    /* FILE *fp; */
     ctx.sock = sock;
 
     strncpy(ctx.my_nick, "You", sizeof(ctx.my_nick) - 1);
-    /* strncpy(ctx.peer_nick, "Peer", sizeof(ctx.peer_nick) - 1); */
     ctx.my_nick[sizeof(ctx.my_nick) - 1] = '\0';
+    /* strncpy(ctx.peer_nick, "Peer", sizeof(ctx.peer_nick) - 1); */
     /* ctx.peer_nick[sizeof(ctx.peer_nick) - 1] = '\0'; */
 
     /* Load saved nickname if it exists */
+    /*
     fp = open_file_in_user_directory("nick.txt", "r");
     if (fp != NULL)
     {
         fscanf(fp, "%63s", ctx.my_nick);
         fclose(fp);
     }
+    */
 
+    /*
     strncpy(ctx.peer_ip, server_ip ? server_ip : "unknown_peer", sizeof(ctx.peer_ip) - 1);
     ctx.peer_ip[sizeof(ctx.peer_ip) - 1] = '\0';
-
+    */
+    /*
     strncpy(ctx.history_path, history_path ? history_path : "", sizeof(ctx.history_path) - 1);
     ctx.history_path[sizeof(ctx.history_path) - 1] = '\0';
-
-    /*ctx.peer_uid[0] = '\0';*/
-    ctx.history_loaded = 0;
+    */
+    /* ctx.peer_uid[0] = '\0'; */
+    /* ctx.history_loaded = 0; */
 
     strncpy(ctx.my_uid, get_uid(), sizeof(ctx.my_uid) - 1);
     ctx.my_uid[sizeof(ctx.my_uid) - 1] = '\0';
+
+    /* TODO: Initialize with server: Issue #42 */
 
     pthread_create(&recv_thread, NULL, receiver, &ctx);
 
@@ -241,6 +249,8 @@ void chat_loop_user(int sock, const char *server_ip, const char *history_path)
         if (!fgets(line, sizeof(line), stdin))
             break;
         strip_newline(line);
+
+        /* TODO: If line is not /, put /msg */
 
         if (line[0] == '/')
         {

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -250,26 +250,30 @@ void chat_loop_user(int sock, const char *server_ip, const char *history_path)
             break;
         strip_newline(line);
 
-        /* TODO: If line is not /, put /msg */
-
-        if (line[0] == '/')
+        if (line[0] != '/')
         {
-            switch (dispatch_send(line + 1, &ctx))
+            size_t len = strlen(line);
+            if (len + 5 < sizeof(line))
             {
-            case COMMAND_SUCCESS:
-                break;
-            case COMMAND_ERROR:
-                printf("Error executing '%s'\n", line);
-                break;
-            case COMMAND_UNRECOGNIZED:
-                printf("Unrecognized command '%s'\n", line);
-                break;
+                memmove(line + 5, line, len + 1); /* include '\0' */
+                memcpy(line, "/msg ", 5);
+            }
+            else
+            {
+                printf("Message too long\n");
+                continue;
             }
         }
-        else
+        switch (dispatch_send(line + 1, &ctx))
         {
-            if (lmp_send(ctx.sock, LMP_MSG, line, (uint32_t)strlen(line)) == 0)
-                lmp_history_append(&ctx, ctx.my_nick, line);
+        case COMMAND_SUCCESS:
+            break;
+        case COMMAND_ERROR:
+            printf("Error executing '%s'\n", line);
+            break;
+        case COMMAND_UNRECOGNIZED:
+            printf("Unrecognized command '%s'\n", line);
+            break;
         }
     }
 

--- a/group_user_comms.c
+++ b/group_user_comms.c
@@ -14,6 +14,7 @@
 #include "lmp.h"
 #include "commands_registry.h"
 #include "directory_manager.h"
+#include "group_commands.h"
 
 Group user_group;
 /* For User */
@@ -237,7 +238,8 @@ void chat_loop_user(int sock, const char *server_ip, const char *history_path)
     strncpy(ctx.my_uid, get_uid(), sizeof(ctx.my_uid) - 1);
     ctx.my_uid[sizeof(ctx.my_uid) - 1] = '\0';
 
-    /* TODO: Initialize with server: Issue #42 */
+    /* Initialize user_member_info with server */
+    user_grp_init_send(sock);
 
     pthread_create(&recv_thread, NULL, receiver, &ctx);
 

--- a/test/test_group_client.c
+++ b/test/test_group_client.c
@@ -7,12 +7,11 @@
 #include "group.h"
 #include "group_comms.h"
 #include "group_user_comms.h"
+#include "group_user.h"
 #include "lmp.h"
 
-/*
-Running Command:
-gcc test_group_client.c group_user_comms.c group.c uid.c directory_manager.c -o test_group_client && ./test_group_client
- */
+extern GroupMember user_member_info; /* Global variable to hold the user's member information */
+
 int main()
 {
     struct sockaddr_in server_addr;
@@ -39,37 +38,21 @@ int main()
     if (user_UDP_to_group_server(&server_addr, &reply) == 1)
     {
         int tcp_socket;
-        GroupMember member = {0};
         printf("Server replied from sin_family: %d\n", server_addr.sin_family);
         printf("\n--- Server Discovered! ---\n");
         printf("Group ID: %s\n", reply.info.group_UID);
         printf("Group Name: %s\n", reply.info.group_name);
 
-        /* Prepare GroupMember struct */
-        strncpy(member.uid, user.uid, sizeof(member.uid) - 1);
-        member.uid[sizeof(member.uid) - 1] = '\0'; /* Ensure null termination */
-        strncpy(member.nickname, nickname, sizeof(member.nickname) - 1);
-        member.nickname[sizeof(member.nickname) - 1] = '\0'; /* Ensure null termination */
+        /* Prepare GroupMember user_member_info */
+        strncpy(user_member_info.uid, user.uid, sizeof(user_member_info.uid) - 1);
+        user_member_info.uid[sizeof(user_member_info.uid) - 1] = '\0'; /* Ensure null termination */
+        strncpy(user_member_info.nickname, nickname, sizeof(user_member_info.nickname) - 1);
+        user_member_info.nickname[sizeof(user_member_info.nickname) - 1] = '\0'; /* Ensure null termination */
 
         if ((tcp_socket = user_TCP_to_group_server(&server_addr)) > 0)
         {
-            /* Receive from server */
-            /*
-            char buffer[1024];
-            int bytes_received;
-            */
             printf("\n--- Connected to Server via TCP ---\n");
-
-            /* Send User's information, GroupMember */
-            if (send(tcp_socket, &member, sizeof(member), 0) == -1)
-            {
-                perror("send failed");
-                close(tcp_socket);
-                return 1;
-            }
-
             group_chat(tcp_socket, "user");
-
             printf("\n--- Closing TCP Connection ---\n");
             close(tcp_socket);
         }

--- a/test/test_group_server.c
+++ b/test/test_group_server.c
@@ -12,21 +12,6 @@ static void *tcp_listen_entry(void *arg)
     return NULL;
 }
 
-static void print_connected_members(void)
-{
-    int i;
-
-    printf("Connected members (%d):\n", connection_count);
-    for (i = 0; i < connection_count; i++)
-    {
-        printf("  [%d] uid=%s nickname=%s socket=%d\n",
-               i + 1,
-               group_connections[i].member.uid,
-               group_connections[i].member.nickname,
-               group_connections[i].tcp_socket);
-    }
-}
-
 /*
 Running Command:
 gcc test_group_server.c group_server_comms.c group.c uid.c directory_manager.c -o test_group_server && ./test_group_server
@@ -63,20 +48,12 @@ int main()
 
         if (strcmp(command, "/list") == 0)
         {
-            print_connected_members();
+            /* TODO: Implement list command */
+            printf("Not implemented yet.\n");
         }
         else if (strcmp(command, "/close") == 0)
         {
-            int i;
-
-            for (i = 0; i < connection_count; i++)
-            {
-                if (group_connections[i].tcp_socket > 0)
-                {
-                    close(group_connections[i].tcp_socket);
-                }
-            }
-
+            /* TODO: Implement close command to close all connections in poll array */
             pthread_cancel(tcp_thread);
             pthread_cancel(udp_thread);
             pthread_join(tcp_thread, NULL);

--- a/test/test_group_server.c
+++ b/test/test_group_server.c
@@ -4,6 +4,9 @@
 #include <unistd.h>
 #include "group.h"
 #include "group_server_comms.h"
+#include "group_server.h"
+
+extern Group current_group;
 
 static void *tcp_listen_entry(void *arg)
 {
@@ -24,6 +27,8 @@ int main()
     pthread_t tcp_thread;
     char command[128];
     int create_status;
+
+    init_group_server(group_UID);
 
     strcpy(current_group.info.group_UID, group_UID);
     current_group.info.group_UID[UID_LENGTH] = '\0'; /* Ensure null termination */


### PR DESCRIPTION
## Major update on Phase 3
### User features
- Now users can edit their nickname via `/nick`, server will update `current_group` and send an update to everyone that the group information has been updated.
- Messages (via `/msg`) are now stored on the server to `history.txt`
- Users can load `history.txt` from server via `/load`

### Developer features
- Update to `group_server_comms.c -> handle_client_data` to handle command type by user via `switch(type)` 
- Simplify `group_user_comms.c -> chat_loop_user` to default sending message to group as `/msg`

### Issues Resolved:
- Resolve #51 
- Resolve #42 
- Resolve #39 
- Resolve #46 

### Resolve but not part of Issues:
- Remove `group_connection` moving forward to use `current_group` & `poll` instead